### PR TITLE
Recipe detail view and home feed

### DIFF
--- a/src/recipes/__tests__/recipes.test.ts
+++ b/src/recipes/__tests__/recipes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import * as schema from '#/db/schema'
-import { createRecipe, getRecipeById } from '#/recipes/crud'
+import { createRecipe, getRecipeById, getAllRecipes } from '#/recipes/crud'
 import { createTag } from '#/tags/crud'
 
 const createTestDb = () => {
@@ -101,5 +101,40 @@ describe('getRecipeById', () => {
     const fetched = await getRecipeById(db, 999)
 
     expect(fetched).toBeNull()
+  })
+})
+
+describe('getAllRecipes', () => {
+  it('returns recipes sorted by newest first, with tags', async () => {
+    const db = createTestDb()
+    const tag = await createTag(db, 'Snabblagat')
+
+    await createRecipe(db, {
+      title: 'Äldre recept',
+      ingredients: ['pasta'],
+      tagIds: [],
+    })
+    await createRecipe(db, {
+      title: 'Nyare recept',
+      ingredients: ['ris'],
+      tagIds: [tag.id],
+    })
+
+    const recipes = await getAllRecipes(db)
+
+    expect(recipes).toHaveLength(2)
+    expect(recipes[0].title).toBe('Nyare recept')
+    expect(recipes[0].tags).toHaveLength(1)
+    expect(recipes[0].tags[0].name).toBe('Snabblagat')
+    expect(recipes[1].title).toBe('Äldre recept')
+    expect(recipes[1].tags).toHaveLength(0)
+  })
+
+  it('returns empty array when no recipes exist', async () => {
+    const db = createTestDb()
+
+    const recipes = await getAllRecipes(db)
+
+    expect(recipes).toEqual([])
   })
 })

--- a/src/recipes/crud.ts
+++ b/src/recipes/crud.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { desc, eq } from 'drizzle-orm'
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import * as schema from '#/db/schema'
@@ -43,6 +43,34 @@ export const createRecipe = async (db: Database, input: CreateRecipeInput) => {
   }
 
   return recipe
+}
+
+export const getAllRecipes = async (db: Database) => {
+  const recipes = await db
+    .select()
+    .from(schema.recipesTable)
+    .orderBy(desc(schema.recipesTable.id))
+
+  const allRecipeTags = await db
+    .select({
+      recipeId: schema.recipeTagsTable.recipeId,
+      tagId: schema.tagsTable.id,
+      tagName: schema.tagsTable.name,
+    })
+    .from(schema.recipeTagsTable)
+    .innerJoin(schema.tagsTable, eq(schema.recipeTagsTable.tagId, schema.tagsTable.id))
+
+  const tagsByRecipeId = new Map<number, { id: number; name: string }[]>()
+  for (const row of allRecipeTags) {
+    const existing = tagsByRecipeId.get(row.recipeId) ?? []
+    existing.push({ id: row.tagId, name: row.tagName })
+    tagsByRecipeId.set(row.recipeId, existing)
+  }
+
+  return recipes.map((recipe) => ({
+    ...recipe,
+    tags: tagsByRecipeId.get(recipe.id) ?? [],
+  }))
 }
 
 export const getRecipeById = async (db: Database, id: number) => {

--- a/src/recipes/server.ts
+++ b/src/recipes/server.ts
@@ -1,7 +1,7 @@
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
 import { getDb } from '#/db/client'
-import { createRecipe } from '#/recipes/crud'
+import { createRecipe, getAllRecipes, getRecipeById } from '#/recipes/crud'
 
 export const saveRecipe = createServerFn({ method: 'POST' })
   .inputValidator(
@@ -18,4 +18,16 @@ export const saveRecipe = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const db = getDb()
     return createRecipe(db, data)
+  })
+
+export const fetchAllRecipes = createServerFn({ method: 'GET' }).handler(async () => {
+  const db = getDb()
+  return getAllRecipes(db)
+})
+
+export const fetchRecipeById = createServerFn({ method: 'GET' })
+  .inputValidator(z.object({ id: z.number() }))
+  .handler(async ({ data }) => {
+    const db = getDb()
+    return getRecipeById(db, data.id)
   })

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ImportRouteImport } from './routes/import'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as RecipesRecipeIdRouteImport } from './routes/recipes/$recipeId'
 import { Route as AdminTagsRouteImport } from './routes/admin/tags'
 import { Route as ApiAuthLogoutRouteImport } from './routes/api/auth/logout'
 import { Route as ApiAuthLoginRouteImport } from './routes/api/auth/login'
@@ -29,6 +30,11 @@ const ImportRoute = ImportRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RecipesRecipeIdRoute = RecipesRecipeIdRouteImport.update({
+  id: '/recipes/$recipeId',
+  path: '/recipes/$recipeId',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AdminTagsRoute = AdminTagsRouteImport.update({
@@ -52,6 +58,7 @@ export interface FileRoutesByFullPath {
   '/import': typeof ImportRoute
   '/login': typeof LoginRoute
   '/admin/tags': typeof AdminTagsRoute
+  '/recipes/$recipeId': typeof RecipesRecipeIdRoute
   '/api/auth/login': typeof ApiAuthLoginRoute
   '/api/auth/logout': typeof ApiAuthLogoutRoute
 }
@@ -60,6 +67,7 @@ export interface FileRoutesByTo {
   '/import': typeof ImportRoute
   '/login': typeof LoginRoute
   '/admin/tags': typeof AdminTagsRoute
+  '/recipes/$recipeId': typeof RecipesRecipeIdRoute
   '/api/auth/login': typeof ApiAuthLoginRoute
   '/api/auth/logout': typeof ApiAuthLogoutRoute
 }
@@ -69,6 +77,7 @@ export interface FileRoutesById {
   '/import': typeof ImportRoute
   '/login': typeof LoginRoute
   '/admin/tags': typeof AdminTagsRoute
+  '/recipes/$recipeId': typeof RecipesRecipeIdRoute
   '/api/auth/login': typeof ApiAuthLoginRoute
   '/api/auth/logout': typeof ApiAuthLogoutRoute
 }
@@ -79,6 +88,7 @@ export interface FileRouteTypes {
     | '/import'
     | '/login'
     | '/admin/tags'
+    | '/recipes/$recipeId'
     | '/api/auth/login'
     | '/api/auth/logout'
   fileRoutesByTo: FileRoutesByTo
@@ -87,6 +97,7 @@ export interface FileRouteTypes {
     | '/import'
     | '/login'
     | '/admin/tags'
+    | '/recipes/$recipeId'
     | '/api/auth/login'
     | '/api/auth/logout'
   id:
@@ -95,6 +106,7 @@ export interface FileRouteTypes {
     | '/import'
     | '/login'
     | '/admin/tags'
+    | '/recipes/$recipeId'
     | '/api/auth/login'
     | '/api/auth/logout'
   fileRoutesById: FileRoutesById
@@ -104,6 +116,7 @@ export interface RootRouteChildren {
   ImportRoute: typeof ImportRoute
   LoginRoute: typeof LoginRoute
   AdminTagsRoute: typeof AdminTagsRoute
+  RecipesRecipeIdRoute: typeof RecipesRecipeIdRoute
   ApiAuthLoginRoute: typeof ApiAuthLoginRoute
   ApiAuthLogoutRoute: typeof ApiAuthLogoutRoute
 }
@@ -129,6 +142,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/recipes/$recipeId': {
+      id: '/recipes/$recipeId'
+      path: '/recipes/$recipeId'
+      fullPath: '/recipes/$recipeId'
+      preLoaderRoute: typeof RecipesRecipeIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/admin/tags': {
@@ -160,6 +180,7 @@ const rootRouteChildren: RootRouteChildren = {
   ImportRoute: ImportRoute,
   LoginRoute: LoginRoute,
   AdminTagsRoute: AdminTagsRoute,
+  RecipesRecipeIdRoute: RecipesRecipeIdRoute,
   ApiAuthLoginRoute: ApiAuthLoginRoute,
   ApiAuthLogoutRoute: ApiAuthLogoutRoute,
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link, redirect } from '@tanstack/react-router'
 import { getIsAuthenticated } from '#/auth/server'
+import { fetchAllRecipes } from '#/recipes/server'
 
 export const Route = createFileRoute('/')({
   beforeLoad: async () => {
@@ -8,10 +9,13 @@ export const Route = createFileRoute('/')({
       throw redirect({ to: '/login' })
     }
   },
+  loader: () => fetchAllRecipes(),
   component: HomePage,
 })
 
 function HomePage() {
+  const recipes = Route.useLoaderData()
+
   return (
     <main className="mx-auto max-w-4xl px-4 py-8">
       <div className="flex items-center justify-between">
@@ -39,7 +43,54 @@ function HomePage() {
           </form>
         </div>
       </div>
-      <p className="mt-8 text-gray-600">Inga recept ännu. Börja med att importera ett!</p>
+
+      {recipes.length === 0 ? (
+        <div className="mt-16 text-center">
+          <p className="text-gray-500">Inga recept ännu.</p>
+          <Link
+            to="/import"
+            className="mt-2 inline-block text-sm font-medium text-gray-900 underline"
+          >
+            Lägg till ditt första recept
+          </Link>
+        </div>
+      ) : (
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {recipes.map((recipe) => (
+            <Link
+              key={recipe.id}
+              to="/recipes/$recipeId"
+              params={{ recipeId: String(recipe.id) }}
+              className="group rounded-xl border border-gray-200 p-4 transition hover:border-gray-300 hover:shadow-sm"
+            >
+              <h2 className="font-semibold group-hover:text-gray-700">{recipe.title}</h2>
+              {recipe.description && (
+                <p className="mt-1 line-clamp-2 text-sm text-gray-500">{recipe.description}</p>
+              )}
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {recipe.cookingTimeMinutes && (
+                  <span className="text-xs text-gray-400">{recipe.cookingTimeMinutes} min</span>
+                )}
+                {recipe.servings && (
+                  <span className="text-xs text-gray-400">{recipe.servings} portioner</span>
+                )}
+              </div>
+              {recipe.tags.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {recipe.tags.map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600"
+                    >
+                      {tag.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
     </main>
   )
 }

--- a/src/routes/recipes/$recipeId.tsx
+++ b/src/routes/recipes/$recipeId.tsx
@@ -1,0 +1,102 @@
+import { createFileRoute, Link, redirect } from '@tanstack/react-router'
+import { useState } from 'react'
+import { getIsAuthenticated } from '#/auth/server'
+import { fetchRecipeById } from '#/recipes/server'
+import { Button } from '#/components/ui/button'
+
+export const Route = createFileRoute('/recipes/$recipeId')({
+  beforeLoad: async () => {
+    const isAuthenticated = await getIsAuthenticated()
+    if (!isAuthenticated) {
+      throw redirect({ to: '/login' })
+    }
+  },
+  loader: async ({ params }) => {
+    const recipe = await fetchRecipeById({ data: { id: parseInt(params.recipeId, 10) } })
+    if (!recipe) {
+      throw new Error('Receptet hittades inte')
+    }
+    return recipe
+  },
+  component: RecipeDetailPage,
+})
+
+function RecipeDetailPage() {
+  const recipe = Route.useLoaderData()
+  const [copied, setCopied] = useState(false)
+
+  const handleCopyIngredients = async () => {
+    const text = recipe.ingredients.join('\n')
+    await navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
+        ← Tillbaka
+      </Link>
+
+      <div className="mt-6">
+        <h1 className="text-3xl font-bold">{recipe.title}</h1>
+        {recipe.description && (
+          <p className="mt-2 text-gray-600">{recipe.description}</p>
+        )}
+
+        <div className="mt-4 flex flex-wrap items-center gap-4 text-sm text-gray-500">
+          {recipe.cookingTimeMinutes && <span>{recipe.cookingTimeMinutes} min</span>}
+          {recipe.servings && <span>{recipe.servings} portioner</span>}
+          {recipe.sourceUrl && (
+            <a
+              href={recipe.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-gray-700"
+            >
+              Källa
+            </a>
+          )}
+        </div>
+
+        {recipe.tags.length > 0 && (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {recipe.tags.map((tag) => (
+              <span
+                key={tag.id}
+                className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700"
+              >
+                {tag.name}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <section className="mt-8">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Ingredienser</h2>
+          <Button variant="ghost" size="sm" onClick={handleCopyIngredients}>
+            {copied ? 'Kopierat!' : 'Kopiera'}
+          </Button>
+        </div>
+        <ul className="mt-3 space-y-1.5">
+          {recipe.ingredients.map((ingredient, i) => (
+            <li key={i} className="text-sm">{ingredient}</li>
+          ))}
+        </ul>
+      </section>
+
+      {recipe.steps && recipe.steps.length > 0 && (
+        <section className="mt-8">
+          <h2 className="text-lg font-semibold">Tillagning</h2>
+          <ol className="mt-3 list-decimal space-y-3 pl-5 text-sm">
+            {recipe.steps.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ol>
+        </section>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- `getAllRecipes` CRUD function returning recipes with tags, sorted newest first (2 new tests)
- Home page displays recipe cards in a responsive grid (1/2/3 columns)
- Recipe cards show title, description, cooking time, servings, and tags
- Empty state with link to import when no recipes exist
- Recipe detail page at `/recipes/:recipeId` with all recipe data
- Copy ingredients to clipboard button with feedback
- Back navigation from recipe detail to home

Closes #5

## Test plan

- [ ] Verify all 23 tests pass (`npm test`)
- [ ] Home page shows recipe cards sorted by newest first
- [ ] Empty state shown when no recipes exist
- [ ] Clicking a recipe card navigates to detail page
- [ ] Recipe detail shows all fields (title, description, ingredients, steps, time, servings, tags)
- [ ] Copy button copies ingredients as plain text
- [ ] Layout works on mobile and desktop
- [ ] Back link navigates to home