### PR TITLE
Photo/OCR recipe import

### DIFF
--- a/src/import/__tests__/ocr-extract.test.ts
+++ b/src/import/__tests__/ocr-extract.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const parseMock = vi.fn()
+
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        parse: parseMock,
+      },
+    },
+  })),
+}))
+
+// Must import after mock setup
+const { extractRecipeFromImages } = await import('#/import/ocr-extract')
+
+describe('extractRecipeFromImages', () => {
+  beforeEach(() => {
+    parseMock.mockReset()
+  })
+
+  it('sends images as base64 content parts and returns parsed recipe', async () => {
+    parseMock.mockResolvedValueOnce({
+      choices: [{
+        message: {
+          parsed: {
+            title: 'Pannkakor',
+            description: 'Klassiska svenska pannkakor',
+            ingredients: ['3 dl mjöl', '6 dl mjölk', '3 ägg', '1 msk smör'],
+            steps: ['Vispa ihop smeten', 'Stek i smör'],
+            cookingTimeMinutes: 20,
+            servings: 4,
+            suggestedTagNames: ['Snabblagat'],
+          },
+        },
+      }],
+    })
+
+    const images = [
+      { base64: 'aW1hZ2UxZGF0YQ==', mimeType: 'image/jpeg' },
+      { base64: 'aW1hZ2UyZGF0YQ==', mimeType: 'image/png' },
+    ]
+
+    const result = await extractRecipeFromImages(images, ['Snabblagat', 'Barnvänligt'], 'test-key')
+
+    expect(result).not.toBeNull()
+    expect(result!.title).toBe('Pannkakor')
+    expect(result!.ingredients).toHaveLength(4)
+    expect(result!.steps).toEqual(['Vispa ihop smeten', 'Stek i smör'])
+    expect(result!.suggestedTagNames).toEqual(['Snabblagat'])
+
+    // Verify images were sent as content parts
+    expect(parseMock).toHaveBeenCalledOnce()
+    const callArgs = parseMock.mock.calls[0][0]
+    const userMessage = callArgs.messages.find((m: { role: string }) => m.role === 'user')
+    expect(userMessage.content).toHaveLength(3) // 1 text + 2 images
+    expect(userMessage.content[1].type).toBe('image_url')
+    expect(userMessage.content[2].type).toBe('image_url')
+  })
+
+  it('returns null when API returns no parsed data', async () => {
+    parseMock.mockResolvedValueOnce({
+      choices: [{ message: { parsed: null } }],
+    })
+
+    const result = await extractRecipeFromImages(
+      [{ base64: 'dGVzdA==', mimeType: 'image/jpeg' }],
+      [],
+      'test-key',
+    )
+
+    expect(result).toBeNull()
+  })
+})

--- a/src/import/ocr-extract.ts
+++ b/src/import/ocr-extract.ts
@@ -1,0 +1,60 @@
+import OpenAI from 'openai'
+import { zodResponseFormat } from 'openai/helpers/zod'
+import { recipeDraftSchema, type RecipeDraft } from '#/import/schema'
+
+type ImageInput = {
+  base64: string
+  mimeType: string
+}
+
+const buildSystemPrompt = (tagNames: string[]) => {
+  const tagSection = tagNames.length > 0
+    ? `\n\nTillgängliga taggar att välja bland: ${tagNames.join(', ')}\nVälj de taggar som passar receptet bäst och returnera dem i fältet "suggestedTagNames". Välj bara taggar från listan ovan.`
+    : ''
+
+  return `Du är en receptextraherare. Du får en eller flera bilder av en kokbokssida och ska extrahera receptet till ett strukturerat format på svenska.
+
+Regler:
+- Extrahera ALLA ingredienser, inte bara några. Var noggrann.
+- Extrahera ALLA tillagningssteg i ordning. Var noggrann.
+- Ingredienser ska vara en lista med strängar, en per ingrediens (inkludera mängd och enhet)
+- Steg ska vara en lista med strängar, ett per steg
+- Tillagningstid i minuter som heltal
+- Portioner som heltal
+- Om flera bilder skickas tillhör de samma recept (t.ex. ett uppslag i en kokbok)
+- Om informationen saknas, sätt fältet till null
+- Svara alltid på svenska${tagSection}`
+}
+
+export const extractRecipeFromImages = async (
+  images: ImageInput[],
+  tagNames: string[],
+  apiKey: string,
+): Promise<RecipeDraft | null> => {
+  const client = new OpenAI({ apiKey })
+
+  const imageContent = images.map((img) => ({
+    type: 'image_url' as const,
+    image_url: { url: `data:${img.mimeType};base64,${img.base64}` },
+  }))
+
+  const completion = await client.chat.completions.parse({
+    model: 'gpt-4o',
+    messages: [
+      { role: 'system', content: buildSystemPrompt(tagNames) },
+      {
+        role: 'user',
+        content: [
+          { type: 'text' as const, text: 'Extrahera receptet från dessa bilder:' },
+          ...imageContent,
+        ],
+      },
+    ],
+    response_format: zodResponseFormat(recipeDraftSchema, 'recipe_draft'),
+  })
+
+  const message = completion.choices[0]?.message
+  if (!message?.parsed) return null
+
+  return message.parsed
+}

--- a/src/import/server.ts
+++ b/src/import/server.ts
@@ -5,6 +5,7 @@ import { getDb } from '#/db/client'
 import { getAllTags } from '#/tags/crud'
 import { extractJsonLdRecipe } from '#/import/extract'
 import { extractRecipeWithAi } from '#/import/ai-extract'
+import { extractRecipeFromImages } from '#/import/ocr-extract'
 import { resolveTagIds } from '#/import/auto-tag'
 import type { RecipeDraft } from '#/import/schema'
 
@@ -48,4 +49,29 @@ export const extractRecipeFromUrl = createServerFn({ method: 'POST' })
     const tagIds = await resolveTagIds(draft, tags, env.OPENAI_API_KEY)
 
     return { ...draft, sourceUrl: data.url, tagIds }
+  })
+
+export const extractRecipeFromPhotos = createServerFn({ method: 'POST' })
+  .inputValidator(
+    z.object({
+      images: z.array(z.object({
+        base64: z.string().min(1),
+        mimeType: z.string().min(1),
+      })).min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    const db = getDb()
+    const tags = await getAllTags(db)
+    const tagNames = tags.map((t) => t.name)
+
+    const draft = await extractRecipeFromImages(data.images, tagNames, env.OPENAI_API_KEY)
+
+    if (!draft) {
+      throw new Error('Kunde inte extrahera något recept från bilderna')
+    }
+
+    const tagIds = await resolveTagIds(draft, tags, env.OPENAI_API_KEY)
+
+    return { ...draft, tagIds }
   })

--- a/src/routes/import.tsx
+++ b/src/routes/import.tsx
@@ -3,13 +3,15 @@ import { useState } from 'react'
 import { getIsAuthenticated } from '#/auth/server'
 import { fetchAllTags } from '#/tags/server'
 import { saveRecipe } from '#/recipes/server'
-import { extractRecipeFromUrl } from '#/import/server'
+import { extractRecipeFromUrl, extractRecipeFromPhotos } from '#/import/server'
+import { recipeToFormData } from '#/recipes/form-utils'
 import { formDataToRecipeInput } from '#/recipes/form-utils'
 import { Button } from '#/components/ui/button'
 import { Input } from '#/components/ui/input'
 import { RecipeForm, type RecipeFormData } from '#/components/recipe-form'
 import {
   ArrowLeftIcon,
+  CameraIcon,
   GlobeAltIcon,
   PencilIcon,
 } from '@heroicons/react/24/outline'
@@ -25,7 +27,7 @@ export const Route = createFileRoute('/import')({
   component: ImportPage,
 })
 
-type ImportTab = 'url' | 'manual'
+type ImportTab = 'url' | 'photo' | 'manual'
 
 function ImportPage() {
   const tags = Route.useLoaderData()
@@ -138,6 +140,18 @@ function ImportPage() {
           </button>
           <button
             type="button"
+            onClick={() => setTab('photo')}
+            className={`flex items-center gap-2 border-b-2 pb-2.5 text-sm font-semibold transition ${
+              tab === 'photo'
+                ? 'border-plum-600 text-plum-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            <CameraIcon className="h-4 w-4" />
+            Från foto
+          </button>
+          <button
+            type="button"
             onClick={() => setTab('manual')}
             className={`flex items-center gap-2 border-b-2 pb-2.5 text-sm font-semibold transition ${
               tab === 'manual'
@@ -177,6 +191,13 @@ function ImportPage() {
           </div>
         )}
 
+        {tab === 'photo' && (
+          <PhotoImport
+            onExtracted={(draft) => setPreviewData(draft)}
+            onError={(msg) => setError(msg)}
+          />
+        )}
+
         {tab === 'manual' && (
           <div className="mt-5 rounded-xl bg-white p-5 ring-1 ring-gray-100">
             <RecipeForm
@@ -188,6 +209,90 @@ function ImportPage() {
           </div>
         )}
       </main>
+    </div>
+  )
+}
+
+type PhotoImportProps = {
+  onExtracted: (data: RecipeFormData) => void
+  onError: (message: string) => void
+}
+
+const fileToBase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      // Remove data:image/...;base64, prefix
+      resolve(result.split(',')[1])
+    }
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}
+
+const PhotoImport = ({ onExtracted, onError }: PhotoImportProps) => {
+  const [files, setFiles] = useState<File[]>([])
+  const [extracting, setExtracting] = useState(false)
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      setFiles(Array.from(e.target.files))
+    }
+  }
+
+  const handleExtract = async () => {
+    if (files.length === 0) return
+    setExtracting(true)
+    try {
+      const images = await Promise.all(
+        files.map(async (file) => ({
+          base64: await fileToBase64(file),
+          mimeType: file.type,
+        })),
+      )
+
+      const result = await extractRecipeFromPhotos({ data: { images } })
+
+      onExtracted({
+        title: result.title,
+        description: result.description ?? '',
+        ingredients: result.ingredients.length > 0 ? result.ingredients : [''],
+        steps: result.steps && result.steps.length > 0 ? result.steps : [''],
+        cookingTimeMinutes: result.cookingTimeMinutes ? String(result.cookingTimeMinutes) : '',
+        servings: result.servings ? String(result.servings) : '',
+        tagIds: result.tagIds,
+      })
+    } catch (err) {
+      console.error('Photo extract failed:', err)
+      onError('Kunde inte extrahera recept från bilderna. Försök med tydligare bilder eller lägg till manuellt.')
+    } finally {
+      setExtracting(false)
+    }
+  }
+
+  return (
+    <div className="mt-5 rounded-xl bg-white p-5 ring-1 ring-gray-100">
+      <p className="text-sm text-gray-500">
+        Ladda upp en eller flera bilder av en kokbokssida. Vi extraherar receptet automatiskt.
+      </p>
+      <div className="mt-4 space-y-4">
+        <input
+          type="file"
+          accept="image/*"
+          multiple
+          onChange={handleFileChange}
+          className="block w-full text-sm text-gray-500 file:mr-4 file:rounded-lg file:border-0 file:bg-gray-100 file:px-4 file:py-2 file:text-sm file:font-medium file:text-gray-700 hover:file:bg-gray-200"
+        />
+        {files.length > 0 && (
+          <p className="text-sm text-gray-500">
+            {files.length} {files.length === 1 ? 'bild' : 'bilder'} vald{files.length === 1 ? '' : 'a'}
+          </p>
+        )}
+        <Button onClick={handleExtract} disabled={extracting || files.length === 0}>
+          {extracting ? 'Extraherar recept...' : 'Extrahera recept'}
+        </Button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- OCR extraction module using GPT-4o Vision API with Zod structured outputs for guaranteed schema compliance
- Support for multiple images per import (for cookbook two-page spreads)
- "Fran foto" tab on the import page with file upload
- Auto-tagging from existing tag taxonomy via AI
- Images handled temporarily (base64 in memory, not persisted to R2)
- Swedish system prompt optimized for cookbook page extraction
- 2 tests with mocked OpenAI API (verifies message structure and null handling)

Closes #9

## Test plan

- [ ] Verify all 49 tests pass (`npm test`)
- [ ] Navigate to import page, select "Fran foto" tab
- [ ] Upload a photo of a cookbook page
- [ ] Verify recipe is extracted and shown in preview
- [ ] Upload multiple images (two-page spread)
- [ ] Edit extracted recipe before saving
- [ ] Verify tags are auto-suggested
- [ ] Verify error message shown for unreadable images