### PR TITLE
Deepen auth module: consolidate guards and responses

### DIFF
--- a/src/auth/guards.ts
+++ b/src/auth/guards.ts
@@ -1,0 +1,16 @@
+import { redirect } from '@tanstack/react-router'
+import { getIsAuthenticated } from '#/auth/server'
+
+export const requireAuth = async () => {
+  const isAuthenticated = await getIsAuthenticated()
+  if (!isAuthenticated) {
+    throw redirect({ to: '/login', search: { error: undefined } })
+  }
+}
+
+export const requireGuest = async () => {
+  const isAuthenticated = await getIsAuthenticated()
+  if (isAuthenticated) {
+    throw redirect({ to: '/' })
+  }
+}

--- a/src/auth/responses.ts
+++ b/src/auth/responses.ts
@@ -1,0 +1,32 @@
+import { env } from 'cloudflare:workers'
+import { verifyPassword, createSessionToken, SESSION_DURATION_SECONDS } from '#/auth/session'
+import { serializeSessionCookie, serializeBlankSessionCookie } from '#/auth/cookies'
+
+export const loginWithPassword = (password: string): Response => {
+  if (!verifyPassword(password, env.APP_PASSWORD)) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: '/login?error=invalid' },
+    })
+  }
+
+  const token = createSessionToken(env.APP_SECRET)
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: '/',
+      'Set-Cookie': serializeSessionCookie(token, SESSION_DURATION_SECONDS),
+    },
+  })
+}
+
+export const logoutSession = (): Response => {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: '/login',
+      'Set-Cookie': serializeBlankSessionCookie(),
+    },
+  })
+}

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -1,9 +1,9 @@
 import crypto from 'node:crypto'
 
-const SESSION_DURATION_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+export const SESSION_DURATION_SECONDS = 30 * 24 * 60 * 60 // 30 days
 
 export const createSessionToken = (secret: string): string => {
-  const expiresAt = Date.now() + SESSION_DURATION_MS
+  const expiresAt = Date.now() + SESSION_DURATION_SECONDS * 1000
   const payload = `${expiresAt}`
   const signature = crypto.createHmac('sha256', secret).update(payload).digest('hex')
   return `${payload}.${signature}`

--- a/src/routes/_authed.tsx
+++ b/src/routes/_authed.tsx
@@ -1,12 +1,7 @@
-import { createFileRoute, Outlet, redirect } from '@tanstack/react-router'
-import { getIsAuthenticated } from '#/auth/server'
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { requireAuth } from '#/auth/guards'
 
 export const Route = createFileRoute('/_authed')({
-  beforeLoad: async () => {
-    const isAuthenticated = await getIsAuthenticated()
-    if (!isAuthenticated) {
-      throw redirect({ to: '/login', search: { error: undefined } })
-    }
-  },
+  beforeLoad: requireAuth,
   component: () => <Outlet />,
 })

--- a/src/routes/api/auth/login.ts
+++ b/src/routes/api/auth/login.ts
@@ -1,9 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { env } from 'cloudflare:workers'
-import { verifyPassword, createSessionToken } from '#/auth/session'
-import { serializeSessionCookie } from '#/auth/cookies'
-
-const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60
+import { loginWithPassword } from '#/auth/responses'
 
 export const Route = createFileRoute('/api/auth/login')({
   server: {
@@ -12,22 +8,14 @@ export const Route = createFileRoute('/api/auth/login')({
         const formData = await request.formData()
         const password = formData.get('password')
 
-        if (typeof password !== 'string' || !verifyPassword(password, env.APP_PASSWORD)) {
+        if (typeof password !== 'string') {
           return new Response(null, {
             status: 302,
             headers: { Location: '/login?error=invalid' },
           })
         }
 
-        const token = createSessionToken(env.APP_SECRET)
-
-        return new Response(null, {
-          status: 302,
-          headers: {
-            Location: '/',
-            'Set-Cookie': serializeSessionCookie(token, THIRTY_DAYS_SECONDS),
-          },
-        })
+        return loginWithPassword(password)
       },
     },
   },

--- a/src/routes/api/auth/logout.ts
+++ b/src/routes/api/auth/logout.ts
@@ -1,18 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { serializeBlankSessionCookie } from '#/auth/cookies'
+import { logoutSession } from '#/auth/responses'
 
 export const Route = createFileRoute('/api/auth/logout')({
   server: {
     handlers: {
-      POST: async () => {
-        return new Response(null, {
-          status: 302,
-          headers: {
-            Location: '/login',
-            'Set-Cookie': serializeBlankSessionCookie(),
-          },
-        })
-      },
+      POST: async () => logoutSession(),
     },
   },
 })

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,16 +1,11 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
-import { getIsAuthenticated } from '#/auth/server'
+import { createFileRoute } from '@tanstack/react-router'
+import { requireGuest } from '#/auth/guards'
 
 export const Route = createFileRoute('/login')({
   validateSearch: (search: Record<string, unknown>) => ({
     error: search.error as string | undefined,
   }),
-  beforeLoad: async () => {
-    const isAuthenticated = await getIsAuthenticated()
-    if (isAuthenticated) {
-      throw redirect({ to: '/' })
-    }
-  },
+  beforeLoad: requireGuest,
   component: LoginPage,
 })
 


### PR DESCRIPTION
## Summary

- **`requireAuth` / `requireGuest` guards** (`auth/guards.ts`): `_authed.tsx` and `login.tsx` now use `beforeLoad: requireAuth` / `beforeLoad: requireGuest` instead of inlined 5-line blocks
- **`loginWithPassword` / `logoutSession` response builders** (`auth/responses.ts`): API route handlers delegate to these instead of assembling token + cookie + redirect manually
- **Single session duration constant**: `SESSION_DURATION_SECONDS` in `session.ts` replaces the duplicated `SESSION_DURATION_MS` / `THIRTY_DAYS_SECONDS` that lived in two files with different units

Closes #74

## Test plan

- [x] `npm run build` passes
- [x] All 105 tests pass
- [ ] Manual: verify login flow works
- [ ] Manual: verify logout redirects to `/login`
- [ ] Manual: verify unauthenticated access redirects to `/login`