### PR TITLE
Add emoji favicon and per-route title tags

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -11,7 +11,10 @@ export const Route = createRootRoute({
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       { title: 'Tallriken' },
     ],
-    links: [{ rel: 'stylesheet', href: appCss }],
+    links: [
+      { rel: 'stylesheet', href: appCss },
+      { rel: 'icon', href: 'data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🍽️</text></svg>', type: 'image/svg+xml' },
+    ],
   }),
   shellComponent: RootDocument,
   component: RootComponent,

--- a/src/routes/_authed/admin/tags.tsx
+++ b/src/routes/_authed/admin/tags.tsx
@@ -13,6 +13,7 @@ import {
 
 export const Route = createFileRoute('/_authed/admin/tags')({
   loader: () => fetchAllTags(),
+  head: () => ({ meta: [{ title: 'Taggar | Tallriken' }] }),
   component: TagsAdminPage,
 })
 

--- a/src/routes/_authed/import.tsx
+++ b/src/routes/_authed/import.tsx
@@ -12,6 +12,7 @@ import { ArrowLeftIcon } from '@heroicons/react/24/outline'
 
 export const Route = createFileRoute('/_authed/import')({
   loader: () => fetchAllTags(),
+  head: () => ({ meta: [{ title: 'Nytt recept | Tallriken' }] }),
   component: ImportPage,
 })
 

--- a/src/routes/_authed/recipes/$recipeId.tsx
+++ b/src/routes/_authed/recipes/$recipeId.tsx
@@ -38,6 +38,7 @@ export const Route = createFileRoute('/_authed/recipes/$recipeId')({
     }
     return { recipe, menuRecipeIds }
   },
+  head: ({ loaderData }) => ({ meta: [{ title: `${loaderData.recipe.title} | Tallriken` }] }),
   component: RecipeDetailPage,
 })
 

--- a/src/routes/_authed/recipes/edit/$recipeId.tsx
+++ b/src/routes/_authed/recipes/edit/$recipeId.tsx
@@ -18,6 +18,7 @@ export const Route = createFileRoute('/_authed/recipes/edit/$recipeId')({
     }
     return { recipe, tags }
   },
+  head: ({ loaderData }) => ({ meta: [{ title: `Redigera ${loaderData.recipe.title} | Tallriken` }] }),
   component: EditRecipePage,
 })
 

--- a/src/routes/_authed/weekly-menu.tsx
+++ b/src/routes/_authed/weekly-menu.tsx
@@ -27,6 +27,7 @@ export const Route = createFileRoute('/_authed/weekly-menu')({
     ])
     return { menu, savedShoppingList }
   },
+  head: () => ({ meta: [{ title: 'Veckans meny | Tallriken' }] }),
   component: WeeklyMenuPage,
 })
 

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -5,6 +5,7 @@ export const Route = createFileRoute('/login')({
   validateSearch: (search: Record<string, unknown>) => ({
     error: search.error as string | undefined,
   }),
+  head: () => ({ meta: [{ title: 'Logga in | Tallriken' }] }),
   beforeLoad: requireGuest,
   component: LoginPage,
 })


### PR DESCRIPTION
## Summary
- Adds a plate emoji (🍽️) as SVG favicon in the root route
- Adds `head` with title meta tag on every route using the TanStack Start `head` property
- Dynamic routes (recipe detail, edit recipe) use `loaderData` for titles like "Pasta Carbonara | Tallriken"

## Routes and titles
| Route | Title |
|---|---|
| `/login` | Logga in \| Tallriken |
| `/` | Tallriken (inherited from root) |
| `/recipes/$recipeId` | {recipe title} \| Tallriken |
| `/recipes/edit/$recipeId` | Redigera {recipe title} \| Tallriken |
| `/import` | Nytt recept \| Tallriken |
| `/admin/tags` | Taggar \| Tallriken |
| `/weekly-menu` | Veckans meny \| Tallriken |

## Test plan
- [ ] Verify favicon shows in browser tab
- [ ] Check title updates when navigating between routes
- [ ] Verify dynamic titles on recipe detail and edit pages