### PR TITLE
Semantic vector search with Cloudflare Vectorize

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,14 @@ Two config files:
 
 Ingredients are stored as JSON arrays of `{ group: string | null, items: string[] }`.
 
+Sync data between local and prod (full replacement, not merge):
+```
+./scripts/db-sync.sh local-to-prod   # Overwrite prod with local data
+./scripts/db-sync.sh prod-to-local   # Overwrite local with prod data
+```
+
+After syncing to prod, trigger vector backfill from the admin page in the UI.
+
 ## Testing patterns
 
 Tests use in-memory SQLite via better-sqlite3. Shared utilities in `src/test-utils.ts`:

--- a/scripts/db-sync.sh
+++ b/scripts/db-sync.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+DB_NAME="tallriken-db"
+LOCAL_DB=".wrangler/state/v3/d1/miniflare-D1DatabaseObject/591bbc95322edaa17f4342b951103c98b0577bdd26c4cda6730c3c0980ca9aa3.sqlite"
+DUMP_FILE="/tmp/tallriken-d1-dump.sql"
+TABLES="tags recipes recipe_tags shopping_lists weekly_menu_items"
+
+usage() {
+  echo "Usage: $0 <local-to-prod|prod-to-local>"
+  echo ""
+  echo "  local-to-prod   Export local D1 data and import into remote prod"
+  echo "  prod-to-local   Export remote prod data and import into local D1"
+  exit 1
+}
+
+dump_local() {
+  echo "Exporting local D1..."
+  rm -f "$DUMP_FILE"
+  for table in $TABLES; do
+    sqlite3 "$LOCAL_DB" ".dump $table" >> "$DUMP_FILE"
+  done
+  echo "Exported to $DUMP_FILE"
+}
+
+dump_remote() {
+  echo "Exporting remote D1..."
+  npx wrangler d1 export "$DB_NAME" --remote --output="$DUMP_FILE" --no-schema
+  echo "Exported to $DUMP_FILE"
+}
+
+import_local() {
+  echo "Clearing local tables..."
+  for table in $(echo "$TABLES" | tr ' ' '\n' | tac); do
+    sqlite3 "$LOCAL_DB" "DELETE FROM $table;"
+  done
+  echo "Importing into local D1..."
+  sqlite3 "$LOCAL_DB" < "$DUMP_FILE"
+  echo "Done"
+}
+
+import_remote() {
+  echo "Clearing remote tables..."
+  for table in $(echo "$TABLES" | tr ' ' '\n' | tac); do
+    npx wrangler d1 execute "$DB_NAME" --remote --command="DELETE FROM $table;"
+  done
+  echo "Importing into remote D1..."
+  npx wrangler d1 execute "$DB_NAME" --remote --file="$DUMP_FILE"
+  echo "Done"
+}
+
+case "${1:-}" in
+  local-to-prod)
+    dump_local
+    import_remote
+    ;;
+  prod-to-local)
+    dump_remote
+    import_local
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+rm -f "$DUMP_FILE"
+echo "Sync complete"

--- a/src/chat/__tests__/recipe-search.test.ts
+++ b/src/chat/__tests__/recipe-search.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createTestDb, createTestRecipe, createTestTag } from '#/test-utils'
-import { createRecipeSearch } from '#/chat/recipe-search'
+import { createRecipeSearch, type FindSimilar } from '#/chat/recipe-search'
 
 describe('recipe search', () => {
   it('finds recipes matching query in title', async () => {
@@ -106,5 +106,90 @@ describe('recipe search', () => {
 
     expect(results.map((r) => r.title)).toContain('Ugnspannkaka')
     expect(results.map((r) => r.title)).not.toContain('Pad Thai')
+  })
+})
+
+describe('recipe search with vector search', () => {
+  it('uses findSimilar when provided and query is non-empty', async () => {
+    const db = createTestDb()
+    const recipe = await createTestRecipe(db, { title: 'Kycklinggryta' })
+
+    const findSimilar: FindSimilar = vi.fn().mockResolvedValue([
+      { recipeId: recipe.id, score: 0.92 },
+    ])
+
+    const search = createRecipeSearch(db, findSimilar)
+    const results = await search.search('krämig kyckling')
+
+    expect(findSimilar).toHaveBeenCalledWith('krämig kyckling')
+    expect(results).toHaveLength(1)
+    expect(results[0].title).toBe('Kycklinggryta')
+  })
+
+  it('falls back to text search when query is empty', async () => {
+    const db = createTestDb()
+    await createTestRecipe(db, { title: 'Pasta Carbonara' })
+    await createTestRecipe(db, { title: 'Pad Thai' })
+
+    const findSimilar: FindSimilar = vi.fn()
+
+    const search = createRecipeSearch(db, findSimilar)
+    const results = await search.search('')
+
+    expect(findSimilar).not.toHaveBeenCalled()
+    expect(results).toHaveLength(2)
+  })
+
+  it('preserves vector similarity ranking', async () => {
+    const db = createTestDb()
+    const first = await createTestRecipe(db, { title: 'Snabb pasta' })
+    const second = await createTestRecipe(db, { title: 'Långsam gryta' })
+
+    const findSimilar: FindSimilar = vi.fn().mockResolvedValue([
+      { recipeId: second.id, score: 0.95 },
+      { recipeId: first.id, score: 0.80 },
+    ])
+
+    const search = createRecipeSearch(db, findSimilar)
+    const results = await search.search('gryta')
+
+    expect(results[0].title).toBe('Långsam gryta')
+    expect(results[1].title).toBe('Snabb pasta')
+  })
+
+  it('applies tag filter on vector results', async () => {
+    const db = createTestDb()
+    const italian = await createTestTag(db, 'Italienskt')
+    const thai = await createTestTag(db, 'Thai')
+    const pasta = await createTestRecipe(db, { title: 'Pasta', tagIds: [italian.id] })
+    const padThai = await createTestRecipe(db, { title: 'Pad Thai', tagIds: [thai.id] })
+
+    const findSimilar: FindSimilar = vi.fn().mockResolvedValue([
+      { recipeId: pasta.id, score: 0.9 },
+      { recipeId: padThai.id, score: 0.8 },
+    ])
+
+    const search = createRecipeSearch(db, findSimilar)
+    const results = await search.search('nudlar', { tags: ['Italienskt'] })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].title).toBe('Pasta')
+  })
+
+  it('applies max cooking time filter on vector results', async () => {
+    const db = createTestDb()
+    const quick = await createTestRecipe(db, { title: 'Snabbsallad', cookingTimeMinutes: 10 })
+    const slow = await createTestRecipe(db, { title: 'Brässerad bog', cookingTimeMinutes: 240 })
+
+    const findSimilar: FindSimilar = vi.fn().mockResolvedValue([
+      { recipeId: quick.id, score: 0.9 },
+      { recipeId: slow.id, score: 0.8 },
+    ])
+
+    const search = createRecipeSearch(db, findSimilar)
+    const results = await search.search('mat', { maxCookingTimeMinutes: 30 })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].title).toBe('Snabbsallad')
   })
 })

--- a/src/chat/recipe-search.ts
+++ b/src/chat/recipe-search.ts
@@ -1,7 +1,7 @@
 import { inArray, sql } from 'drizzle-orm'
 import * as schema from '#/db/schema'
 import type { Database } from '#/db/types'
-import { searchRecipes, getAllRecipes } from '#/recipes/crud'
+import { searchRecipes, getAllRecipes, getRecipesByIds } from '#/recipes/crud'
 
 export type CompactRecipeResult = {
   id: number
@@ -21,43 +21,89 @@ type SearchFilters = {
   maxCookingTimeMinutes?: number
 }
 
-export const createRecipeSearch = (db: Database) => ({
+export type FindSimilar = (query: string) => Promise<{ recipeId: number; score: number }[]>
+
+export const createRecipeSearch = (db: Database, findSimilar?: FindSimilar) => ({
   search: async (query: string, filters?: SearchFilters): Promise<CompactRecipeResult[]> => {
-    const explicitTagIds = await resolveTagNames(db, filters?.tags)
-    const fuzzyTagIds = query ? await fuzzyMatchTags(db, query) : []
-    const allTagIds = [...new Set([...explicitTagIds, ...fuzzyTagIds])]
-
-    const textResults = query
-      ? await searchRecipes(db, {
-          query,
-          maxCookingTimeMinutes: filters?.maxCookingTimeMinutes,
-        })
-      : []
-
-    const tagResults = allTagIds.length > 0
-      ? await searchRecipes(db, {
-          tagIds: allTagIds,
-          maxCookingTimeMinutes: filters?.maxCookingTimeMinutes,
-        })
-      : []
-
-    if (!query && allTagIds.length === 0) {
-      const all = await searchRecipes(db, {
-        maxCookingTimeMinutes: filters?.maxCookingTimeMinutes,
-      })
-      return all.map(formatResult)
+    if (findSimilar && query) {
+      return vectorSearch(db, findSimilar, query, filters)
     }
 
-    const seen = new Set<number>()
-    const merged = [...tagResults, ...textResults].filter((r) => {
-      if (seen.has(r.id)) return false
-      seen.add(r.id)
-      return true
-    })
-
-    return merged.map(formatResult)
+    return fallbackSearch(db, query, filters)
   },
 })
+
+const vectorSearch = async (
+  db: Database,
+  findSimilar: FindSimilar,
+  query: string,
+  filters?: SearchFilters,
+): Promise<CompactRecipeResult[]> => {
+  const similar = await findSimilar(query)
+  if (similar.length === 0) return []
+
+  const recipeIds = similar.map((s) => s.recipeId)
+  const recipes = await getRecipesByIds(db, recipeIds)
+
+  const explicitTagIds = await resolveTagNames(db, filters?.tags)
+
+  const filtered = recipes.filter((r) => {
+    if (filters?.maxCookingTimeMinutes && r.cookingTimeMinutes != null) {
+      if (r.cookingTimeMinutes > filters.maxCookingTimeMinutes) return false
+    }
+    if (explicitTagIds.length > 0) {
+      const recipeTagIds = r.tags.map((t) => t.id)
+      if (!explicitTagIds.some((id) => recipeTagIds.includes(id))) return false
+    }
+    return true
+  })
+
+  // Preserve vector similarity ranking
+  const idOrder = new Map(recipeIds.map((id, i) => [id, i]))
+  filtered.sort((a, b) => (idOrder.get(a.id) ?? 0) - (idOrder.get(b.id) ?? 0))
+
+  return filtered.map(formatResult)
+}
+
+const fallbackSearch = async (
+  db: Database,
+  query: string,
+  filters?: SearchFilters,
+): Promise<CompactRecipeResult[]> => {
+  const explicitTagIds = await resolveTagNames(db, filters?.tags)
+  const fuzzyTagIds = query ? await fuzzyMatchTags(db, query) : []
+  const allTagIds = [...new Set([...explicitTagIds, ...fuzzyTagIds])]
+
+  const textResults = query
+    ? await searchRecipes(db, {
+        query,
+        maxCookingTimeMinutes: filters?.maxCookingTimeMinutes,
+      })
+    : []
+
+  const tagResults = allTagIds.length > 0
+    ? await searchRecipes(db, {
+        tagIds: allTagIds,
+        maxCookingTimeMinutes: filters?.maxCookingTimeMinutes,
+      })
+    : []
+
+  if (!query && allTagIds.length === 0) {
+    const all = await searchRecipes(db, {
+      maxCookingTimeMinutes: filters?.maxCookingTimeMinutes,
+    })
+    return all.map(formatResult)
+  }
+
+  const seen = new Set<number>()
+  const merged = [...tagResults, ...textResults].filter((r) => {
+    if (seen.has(r.id)) return false
+    seen.add(r.id)
+    return true
+  })
+
+  return merged.map(formatResult)
+}
 
 const formatResult = (r: Awaited<ReturnType<typeof getAllRecipes>>[number]): CompactRecipeResult => ({
   id: r.id,

--- a/src/chat/tools.ts
+++ b/src/chat/tools.ts
@@ -2,6 +2,7 @@ import { toolDefinition } from '@tanstack/ai'
 import { z } from 'zod'
 import { getDb } from '#/db/client'
 import { createRecipeSearch } from '#/chat/recipe-search'
+import { getVectorSearch } from '#/vector/client'
 import { getMenu, addToMenu } from '#/menu/crud'
 
 const recipeResultSchema = z.object({
@@ -38,7 +39,10 @@ const searchRecipesDef = toolDefinition({
 export const searchRecipesTool = searchRecipesDef.server(
   async ({ query, maxCookingTimeMinutes, tags }) => {
     const db = getDb()
-    const search = createRecipeSearch(db)
+    const vectorSearch = getVectorSearch()
+    const search = createRecipeSearch(db, (q) =>
+      vectorSearch.findSimilar({ query: q, topK: 15 }),
+    )
     const results = await search.search(query, { maxCookingTimeMinutes, tags })
     return results.map((r) => ({
       ...r,

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -8,6 +8,7 @@ type ConfirmDialogProps = {
   title: string
   description: string
   confirmLabel?: string
+  confirmVariant?: 'primary' | 'danger'
   onConfirm: () => void
 }
 
@@ -17,6 +18,7 @@ const ConfirmDialog = ({
   title,
   description,
   confirmLabel = 'Ta bort',
+  confirmVariant = 'danger',
   onConfirm,
 }: ConfirmDialogProps) => {
   return (
@@ -42,7 +44,7 @@ const ConfirmDialog = ({
               render={<Button variant="ghost">Avbryt</Button>}
             />
             <Button
-              variant="danger"
+              variant={confirmVariant}
               onClick={() => {
                 onConfirm()
                 onOpenChange(false)

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,7 @@ declare module 'cloudflare:workers' {
   interface CloudflareEnv {
     DB: D1Database
     R2: R2Bucket
+    VECTORIZE: VectorizeIndex
     APP_PASSWORD: string
     APP_SECRET: string
     OPENAI_API_KEY: string

--- a/src/recipes/crud.ts
+++ b/src/recipes/crud.ts
@@ -173,6 +173,17 @@ const attachTags = async (db: Database, recipes: (typeof schema.recipesTable.$in
   }))
 }
 
+export const getRecipesByIds = async (db: Database, ids: number[]) => {
+  if (ids.length === 0) return []
+
+  const recipes = await db
+    .select()
+    .from(schema.recipesTable)
+    .where(inArray(schema.recipesTable.id, ids))
+
+  return attachTags(db, recipes)
+}
+
 export const getFavoriteRecipes = async (db: Database, limit: number) => {
   const recipes = await db
     .select()

--- a/src/recipes/server.ts
+++ b/src/recipes/server.ts
@@ -1,16 +1,21 @@
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
 import { getDb } from '#/db/client'
-import { createRecipe, getAllRecipes, getRecipeById, updateRecipe, deleteRecipe, searchRecipes, getFavoriteRecipes, getStaleRecipes } from '#/recipes/crud'
+import { createRecipe, getAllRecipes, getRecipeById, getRecipesByIds, updateRecipe, deleteRecipe, searchRecipes, getFavoriteRecipes, getStaleRecipes } from '#/recipes/crud'
 import { recipeInputSchema } from '#/recipes/recipe'
 import { authMiddleware } from '#/auth/middleware'
+import { getVectorSearch } from '#/vector/client'
+import { syncRecipeVector } from '#/vector/sync'
+import { env } from 'cloudflare:workers'
 
 export const saveRecipe = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(recipeInputSchema)
   .handler(async ({ data }) => {
     const db = getDb()
-    return createRecipe(db, data)
+    const recipe = await createRecipe(db, data)
+    await syncRecipeVector(getVectorSearch(), env.OPENAI_API_KEY, db, recipe, data.tagIds)
+    return recipe
   })
 
 export const editRecipe = createServerFn({ method: 'POST' })
@@ -19,7 +24,9 @@ export const editRecipe = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const db = getDb()
     const { id, ...input } = data
-    return updateRecipe(db, id, input)
+    const recipe = await updateRecipe(db, id, input)
+    await syncRecipeVector(getVectorSearch(), env.OPENAI_API_KEY, db, recipe, input.tagIds)
+    return recipe
   })
 
 export const removeRecipe = createServerFn({ method: 'POST' })
@@ -28,6 +35,7 @@ export const removeRecipe = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const db = getDb()
     await deleteRecipe(db, data.id)
+    await getVectorSearch().remove(data.id)
   })
 
 export const fetchAllRecipes = createServerFn({ method: 'GET' })
@@ -56,6 +64,31 @@ export const findRecipes = createServerFn({ method: 'GET' })
   )
   .handler(async ({ data }) => {
     const db = getDb()
+    const hasQuery = data.query && data.query.trim().length > 0
+    const hasTagFilter = data.tagIds && data.tagIds.length > 0
+
+    // Vector search for freetext queries without tag filters
+    if (hasQuery && !hasTagFilter) {
+      const vectorSearch = getVectorSearch()
+      const similar = await vectorSearch.findSimilar({ query: data.query!, topK: 20 })
+
+      if (similar.length > 0) {
+        const recipeIds = similar.map((s) => s.recipeId)
+        const recipes = await getRecipesByIds(db, recipeIds)
+
+        const filtered = data.maxCookingTimeMinutes
+          ? recipes.filter((r) => r.cookingTimeMinutes != null && r.cookingTimeMinutes <= data.maxCookingTimeMinutes!)
+          : recipes
+
+        // Preserve vector similarity ranking
+        const idOrder = new Map(recipeIds.map((id, i) => [id, i]))
+        filtered.sort((a, b) => (idOrder.get(a.id) ?? 0) - (idOrder.get(b.id) ?? 0))
+
+        return filtered
+      }
+    }
+
+    // D1 search for tag-only, filter-only, or empty queries
     return searchRecipes(db, data)
   })
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ApiImagesSplatRouteImport } from './routes/api/images/$'
 import { Route as ApiAuthLogoutRouteImport } from './routes/api/auth/logout'
 import { Route as ApiAuthLoginRouteImport } from './routes/api/auth/login'
 import { Route as AuthedRecipesRecipeIdRouteImport } from './routes/_authed/recipes/$recipeId'
+import { Route as AuthedAdminVectorsRouteImport } from './routes/_authed/admin/vectors'
 import { Route as AuthedAdminTagsRouteImport } from './routes/_authed/admin/tags'
 import { Route as AuthedRecipesEditRecipeIdRouteImport } from './routes/_authed/recipes/edit/$recipeId'
 
@@ -71,6 +72,11 @@ const AuthedRecipesRecipeIdRoute = AuthedRecipesRecipeIdRouteImport.update({
   path: '/recipes/$recipeId',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedAdminVectorsRoute = AuthedAdminVectorsRouteImport.update({
+  id: '/admin/vectors',
+  path: '/admin/vectors',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedAdminTagsRoute = AuthedAdminTagsRouteImport.update({
   id: '/admin/tags',
   path: '/admin/tags',
@@ -90,6 +96,7 @@ export interface FileRoutesByFullPath {
   '/weekly-menu': typeof AuthedWeeklyMenuRoute
   '/api/chat': typeof ApiChatRoute
   '/admin/tags': typeof AuthedAdminTagsRoute
+  '/admin/vectors': typeof AuthedAdminVectorsRoute
   '/recipes/$recipeId': typeof AuthedRecipesRecipeIdRoute
   '/api/auth/login': typeof ApiAuthLoginRoute
   '/api/auth/logout': typeof ApiAuthLogoutRoute
@@ -103,6 +110,7 @@ export interface FileRoutesByTo {
   '/api/chat': typeof ApiChatRoute
   '/': typeof AuthedIndexRoute
   '/admin/tags': typeof AuthedAdminTagsRoute
+  '/admin/vectors': typeof AuthedAdminVectorsRoute
   '/recipes/$recipeId': typeof AuthedRecipesRecipeIdRoute
   '/api/auth/login': typeof ApiAuthLoginRoute
   '/api/auth/logout': typeof ApiAuthLogoutRoute
@@ -118,6 +126,7 @@ export interface FileRoutesById {
   '/api/chat': typeof ApiChatRoute
   '/_authed/': typeof AuthedIndexRoute
   '/_authed/admin/tags': typeof AuthedAdminTagsRoute
+  '/_authed/admin/vectors': typeof AuthedAdminVectorsRoute
   '/_authed/recipes/$recipeId': typeof AuthedRecipesRecipeIdRoute
   '/api/auth/login': typeof ApiAuthLoginRoute
   '/api/auth/logout': typeof ApiAuthLogoutRoute
@@ -133,6 +142,7 @@ export interface FileRouteTypes {
     | '/weekly-menu'
     | '/api/chat'
     | '/admin/tags'
+    | '/admin/vectors'
     | '/recipes/$recipeId'
     | '/api/auth/login'
     | '/api/auth/logout'
@@ -146,6 +156,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/'
     | '/admin/tags'
+    | '/admin/vectors'
     | '/recipes/$recipeId'
     | '/api/auth/login'
     | '/api/auth/logout'
@@ -160,6 +171,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/_authed/'
     | '/_authed/admin/tags'
+    | '/_authed/admin/vectors'
     | '/_authed/recipes/$recipeId'
     | '/api/auth/login'
     | '/api/auth/logout'
@@ -248,6 +260,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedRecipesRecipeIdRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/admin/vectors': {
+      id: '/_authed/admin/vectors'
+      path: '/admin/vectors'
+      fullPath: '/admin/vectors'
+      preLoaderRoute: typeof AuthedAdminVectorsRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/admin/tags': {
       id: '/_authed/admin/tags'
       path: '/admin/tags'
@@ -270,6 +289,7 @@ interface AuthedRouteChildren {
   AuthedWeeklyMenuRoute: typeof AuthedWeeklyMenuRoute
   AuthedIndexRoute: typeof AuthedIndexRoute
   AuthedAdminTagsRoute: typeof AuthedAdminTagsRoute
+  AuthedAdminVectorsRoute: typeof AuthedAdminVectorsRoute
   AuthedRecipesRecipeIdRoute: typeof AuthedRecipesRecipeIdRoute
   AuthedRecipesEditRecipeIdRoute: typeof AuthedRecipesEditRecipeIdRoute
 }
@@ -279,6 +299,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedWeeklyMenuRoute: AuthedWeeklyMenuRoute,
   AuthedIndexRoute: AuthedIndexRoute,
   AuthedAdminTagsRoute: AuthedAdminTagsRoute,
+  AuthedAdminVectorsRoute: AuthedAdminVectorsRoute,
   AuthedRecipesRecipeIdRoute: AuthedRecipesRecipeIdRoute,
   AuthedRecipesEditRecipeIdRoute: AuthedRecipesEditRecipeIdRoute,
 }

--- a/src/routes/_authed/admin/vectors.tsx
+++ b/src/routes/_authed/admin/vectors.tsx
@@ -1,0 +1,88 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useState } from 'react'
+import { Button } from '#/components/ui/button'
+import { ConfirmDialog } from '#/components/ui/confirm-dialog'
+import { triggerBackfill } from '#/vector/server'
+import {
+  ArrowLeftIcon,
+  ArrowPathIcon,
+} from '@heroicons/react/24/outline'
+
+export const Route = createFileRoute('/_authed/admin/vectors')({
+  head: () => ({ meta: [{ title: 'Vektorsök | Tallriken' }] }),
+  component: VectorsAdminPage,
+})
+
+function VectorsAdminPage() {
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+  const [result, setResult] = useState<string | null>(null)
+
+  const handleBackfill = async () => {
+    setStatus('loading')
+    setResult(null)
+    try {
+      const response = await triggerBackfill()
+      setStatus('success')
+      setResult(`${response.total} recept embeddade`)
+    } catch {
+      setStatus('error')
+      setResult('Något gick fel vid backfill')
+    }
+  }
+
+  return (
+    <div className="min-h-screen">
+      <nav className="border-b border-gray-100 bg-white">
+        <div className="mx-auto flex max-w-4xl items-center px-4 py-3">
+          <Link to="/" className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800">
+            <ArrowLeftIcon className="h-4 w-4" />
+            Tillbaka
+          </Link>
+        </div>
+      </nav>
+
+      <main className="mx-auto max-w-4xl px-4 py-8">
+        <h1 className="text-2xl font-extrabold tracking-tight text-gray-900">Vektorsök</h1>
+        <p className="mt-2 text-sm text-gray-500">
+          Hantera vektordatabasen som driver semantisk sökning. Kör backfill efter att du synkat receptdata till prod.
+        </p>
+
+        <div className="mt-6 rounded-xl bg-white p-5 ring-1 ring-gray-100">
+          <h2 className="text-sm font-bold text-gray-900">Backfill embeddings</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Genererar nya embeddings för alla recept. Befintliga vektorer skrivs över.
+          </p>
+
+          <div className="mt-4 flex items-center gap-3">
+            <Button
+              onClick={() => setShowConfirm(true)}
+              disabled={status === 'loading'}
+            >
+              <ArrowPathIcon className={`mr-1.5 h-4 w-4 ${status === 'loading' ? 'animate-spin' : ''}`} />
+              {status === 'loading' ? 'Kör backfill...' : 'Kör backfill'}
+            </Button>
+          </div>
+
+          {result && (
+            <div className={`mt-4 rounded-xl px-3 py-2 text-sm ${
+              status === 'success' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-600'
+            }`}>
+              {result}
+            </div>
+          )}
+        </div>
+      </main>
+
+      <ConfirmDialog
+        open={showConfirm}
+        onOpenChange={setShowConfirm}
+        title="Kör backfill"
+        description="Detta genererar nya embeddings för alla recept via OpenAI. Det kan ta en stund beroende på antal recept."
+        confirmLabel="Kör backfill"
+        confirmVariant="primary"
+        onConfirm={handleBackfill}
+      />
+    </div>
+  )
+}

--- a/src/routes/_authed/index.tsx
+++ b/src/routes/_authed/index.tsx
@@ -20,6 +20,7 @@ import {
   CalendarIcon,
   EllipsisVerticalIcon,
   TagIcon,
+  MagnifyingGlassCircleIcon,
   ArrowRightStartOnRectangleIcon,
 } from '@heroicons/react/24/outline'
 
@@ -196,6 +197,12 @@ function HomePage() {
                   <Link to="/admin/tags" className="flex items-center gap-2.5">
                     <TagIcon className="h-4 w-4 text-gray-400" />
                     Taggar
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <Link to="/admin/vectors" className="flex items-center gap-2.5">
+                    <MagnifyingGlassCircleIcon className="h-4 w-4 text-gray-400" />
+                    Vektorsök
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />

--- a/src/tags/server.ts
+++ b/src/tags/server.ts
@@ -1,8 +1,14 @@
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
+import { eq } from 'drizzle-orm'
+import { env } from 'cloudflare:workers'
 import { getDb } from '#/db/client'
 import { createTag, getAllTags, renameTag, deleteTag } from '#/tags/crud'
 import { authMiddleware } from '#/auth/middleware'
+import * as schema from '#/db/schema'
+import { getVectorSearch } from '#/vector/client'
+import { syncRecipeVector } from '#/vector/sync'
+import { getRecipesByIds } from '#/recipes/crud'
 
 export const fetchAllTags = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
@@ -24,7 +30,26 @@ export const updateTagName = createServerFn({ method: 'POST' })
   .inputValidator(z.object({ id: z.number(), name: z.string().min(1) }))
   .handler(async ({ data }) => {
     const db = getDb()
-    return renameTag(db, data.id, data.name)
+    const tag = await renameTag(db, data.id, data.name)
+
+    const recipeTagRows = await db
+      .select({ recipeId: schema.recipeTagsTable.recipeId })
+      .from(schema.recipeTagsTable)
+      .where(eq(schema.recipeTagsTable.tagId, data.id))
+
+    if (recipeTagRows.length > 0) {
+      const vectorSearch = getVectorSearch()
+      const recipeIds = recipeTagRows.map((r) => r.recipeId)
+      const recipes = await getRecipesByIds(db, recipeIds)
+
+      await Promise.all(
+        recipes.map((recipe) =>
+          syncRecipeVector(vectorSearch, env.OPENAI_API_KEY, db, recipe, recipe.tags.map((t) => t.id)),
+        ),
+      )
+    }
+
+    return tag
   })
 
 export const removeTag = createServerFn({ method: 'POST' })

--- a/src/vector/__tests__/embed.test.ts
+++ b/src/vector/__tests__/embed.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { buildEmbeddingText } from '#/vector/embed'
+
+describe('buildEmbeddingText', () => {
+  it('includes all fields when present', () => {
+    const result = buildEmbeddingText({
+      title: 'Pasta Carbonara',
+      tags: ['Italienskt', 'Snabblagat'],
+      description: 'Klassisk krämig pasta',
+      cookingTimeMinutes: 25,
+    })
+
+    expect(result).toBe('Pasta Carbonara | Italienskt, Snabblagat | Klassisk krämig pasta | 25 min')
+  })
+
+  it('omits tags when empty', () => {
+    const result = buildEmbeddingText({
+      title: 'Enkel soppa',
+      tags: [],
+      description: 'Snabb vardagsmat',
+      cookingTimeMinutes: 15,
+    })
+
+    expect(result).toBe('Enkel soppa | Snabb vardagsmat | 15 min')
+  })
+
+  it('omits description when null', () => {
+    const result = buildEmbeddingText({
+      title: 'Pannkakor',
+      tags: ['Barnvänligt'],
+      description: null,
+      cookingTimeMinutes: 30,
+    })
+
+    expect(result).toBe('Pannkakor | Barnvänligt | 30 min')
+  })
+
+  it('omits cooking time when null', () => {
+    const result = buildEmbeddingText({
+      title: 'Sallad',
+      tags: ['Lunch'],
+      description: 'Fräsch sallad',
+      cookingTimeMinutes: null,
+    })
+
+    expect(result).toBe('Sallad | Lunch | Fräsch sallad')
+  })
+
+  it('returns only title when all other fields are empty/null', () => {
+    const result = buildEmbeddingText({
+      title: 'Smörgås',
+      tags: [],
+      description: null,
+      cookingTimeMinutes: null,
+    })
+
+    expect(result).toBe('Smörgås')
+  })
+})

--- a/src/vector/__tests__/sync.test.ts
+++ b/src/vector/__tests__/sync.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createTestDb, createTestTag } from '#/test-utils'
+import { syncRecipeVector } from '#/vector/sync'
+import type { VectorSearch } from '#/vector/search'
+
+vi.mock('#/vector/embed', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('#/vector/embed')>()
+  return {
+    ...actual,
+    embed: vi.fn().mockResolvedValue(new Array(1536).fill(0.1)),
+  }
+})
+
+const createMockVectorSearch = (): VectorSearch & { upsertCalls: unknown[][] } => {
+  const upsertCalls: unknown[][] = []
+  return {
+    upsertCalls,
+    findSimilar: vi.fn().mockResolvedValue([]),
+    upsert: vi.fn(async (...args: unknown[]) => {
+      upsertCalls.push(args)
+    }),
+    remove: vi.fn(),
+  }
+}
+
+describe('syncRecipeVector', () => {
+  it('embeds recipe with tag names and upserts vector', async () => {
+    const db = createTestDb()
+    const tag = await createTestTag(db, 'Italienskt')
+    const vectorSearch = createMockVectorSearch()
+
+    await syncRecipeVector(vectorSearch, 'test-api-key', db, {
+      id: 1,
+      title: 'Pasta Carbonara',
+      description: 'Klassisk pasta',
+      cookingTimeMinutes: 25,
+    }, [tag.id])
+
+    expect(vectorSearch.upsert).toHaveBeenCalledWith(
+      1,
+      expect.any(Array),
+      { tagNames: ['Italienskt'], cookingTimeMinutes: 25 },
+    )
+  })
+
+  it('handles recipe with no tags', async () => {
+    const db = createTestDb()
+    const vectorSearch = createMockVectorSearch()
+
+    await syncRecipeVector(vectorSearch, 'test-api-key', db, {
+      id: 2,
+      title: 'Enkel soppa',
+      description: null,
+      cookingTimeMinutes: null,
+    }, [])
+
+    expect(vectorSearch.upsert).toHaveBeenCalledWith(
+      2,
+      expect.any(Array),
+      { tagNames: [], cookingTimeMinutes: 0 },
+    )
+  })
+
+  it('resolves multiple tag names from ids', async () => {
+    const db = createTestDb()
+    const tag1 = await createTestTag(db, 'Snabblagat')
+    const tag2 = await createTestTag(db, 'Barnvänligt')
+    const vectorSearch = createMockVectorSearch()
+
+    await syncRecipeVector(vectorSearch, 'test-api-key', db, {
+      id: 3,
+      title: 'Pannkakor',
+      description: 'Snabba pannkakor',
+      cookingTimeMinutes: 15,
+    }, [tag1.id, tag2.id])
+
+    const metadata = vectorSearch.upsertCalls[0][2] as Record<string, unknown>
+    expect(metadata.tagNames).toHaveLength(2)
+    expect(metadata.tagNames).toContain('Snabblagat')
+    expect(metadata.tagNames).toContain('Barnvänligt')
+  })
+})

--- a/src/vector/backfill.ts
+++ b/src/vector/backfill.ts
@@ -1,0 +1,30 @@
+import { getAllRecipes } from '#/recipes/crud'
+import type { Database } from '#/db/types'
+import type { VectorSearch } from '#/vector/search'
+import { syncRecipeVector } from '#/vector/sync'
+
+const chunk = <T>(array: T[], size: number): T[][] => {
+  const chunks: T[][] = []
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size))
+  }
+  return chunks
+}
+
+export const backfillAllRecipes = async (
+  db: Database,
+  vectorSearch: VectorSearch,
+  apiKey: string,
+): Promise<{ total: number }> => {
+  const recipes = await getAllRecipes(db)
+
+  for (const batch of chunk(recipes, 10)) {
+    await Promise.all(
+      batch.map((recipe) =>
+        syncRecipeVector(vectorSearch, apiKey, db, recipe, recipe.tags.map((t) => t.id)),
+      ),
+    )
+  }
+
+  return { total: recipes.length }
+}

--- a/src/vector/client.ts
+++ b/src/vector/client.ts
@@ -1,0 +1,6 @@
+import { env } from 'cloudflare:workers'
+import { createVectorSearch } from '#/vector/search'
+
+export const getVectorSearch = () => {
+  return createVectorSearch(env.VECTORIZE, env.OPENAI_API_KEY)
+}

--- a/src/vector/embed.ts
+++ b/src/vector/embed.ts
@@ -1,0 +1,37 @@
+import OpenAI from 'openai'
+
+type EmbeddingInput = {
+  title: string
+  tags: string[]
+  description: string | null
+  cookingTimeMinutes: number | null
+}
+
+export const buildEmbeddingText = (recipe: EmbeddingInput): string => {
+  const parts = [recipe.title]
+
+  if (recipe.tags.length > 0) {
+    parts.push(recipe.tags.join(', '))
+  }
+
+  if (recipe.description) {
+    parts.push(recipe.description)
+  }
+
+  if (recipe.cookingTimeMinutes != null) {
+    parts.push(`${recipe.cookingTimeMinutes} min`)
+  }
+
+  return parts.join(' | ')
+}
+
+export const embed = async (text: string, apiKey: string): Promise<number[]> => {
+  const openai = new OpenAI({ apiKey })
+
+  const response = await openai.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: text,
+  })
+
+  return response.data[0].embedding
+}

--- a/src/vector/search.ts
+++ b/src/vector/search.ts
@@ -1,0 +1,53 @@
+import { embed } from '#/vector/embed'
+
+type FindSimilarOptions = {
+  query: string
+  topK?: number
+  filter?: VectorizeVectorMetadataFilter
+}
+
+export type FindSimilarResult = {
+  recipeId: number
+  score: number
+}
+
+export type VectorSearch = ReturnType<typeof createVectorSearch>
+
+export const createVectorSearch = (vectorize: VectorizeIndex, apiKey: string) => ({
+  findSimilar: async ({
+    query,
+    topK = 10,
+    filter,
+  }: FindSimilarOptions): Promise<FindSimilarResult[]> => {
+    const queryVector = await embed(query, apiKey)
+
+    const results = await vectorize.query(queryVector, {
+      topK,
+      filter,
+      returnMetadata: 'none',
+    })
+
+    return results.matches.map((match) => ({
+      recipeId: Number(match.id),
+      score: match.score,
+    }))
+  },
+
+  upsert: async (
+    recipeId: number,
+    vector: number[],
+    metadata: Record<string, string | number | string[]>,
+  ): Promise<void> => {
+    await vectorize.upsert([
+      {
+        id: String(recipeId),
+        values: vector,
+        metadata,
+      },
+    ])
+  },
+
+  remove: async (recipeId: number): Promise<void> => {
+    await vectorize.deleteByIds([String(recipeId)])
+  },
+})

--- a/src/vector/server.ts
+++ b/src/vector/server.ts
@@ -1,0 +1,15 @@
+import { createServerFn } from '@tanstack/react-start'
+import { env } from 'cloudflare:workers'
+import { getDb } from '#/db/client'
+import { getVectorSearch } from '#/vector/client'
+import { backfillAllRecipes } from '#/vector/backfill'
+import { authMiddleware } from '#/auth/middleware'
+
+export const triggerBackfill = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .handler(async () => {
+    const db = getDb()
+    const vectorSearch = getVectorSearch()
+    const result = await backfillAllRecipes(db, vectorSearch, env.OPENAI_API_KEY)
+    return result
+  })

--- a/src/vector/sync.ts
+++ b/src/vector/sync.ts
@@ -1,0 +1,42 @@
+import { inArray } from 'drizzle-orm'
+import * as schema from '#/db/schema'
+import type { Database } from '#/db/types'
+import type { VectorSearch } from '#/vector/search'
+import { buildEmbeddingText, embed } from '#/vector/embed'
+
+type SyncRecipe = {
+  id: number
+  title: string
+  description: string | null
+  cookingTimeMinutes: number | null
+}
+
+export const syncRecipeVector = async (
+  vectorSearch: VectorSearch,
+  apiKey: string,
+  db: Database,
+  recipe: SyncRecipe,
+  tagIds: number[],
+): Promise<void> => {
+  const tagNames = tagIds.length > 0
+    ? (await db
+        .select({ name: schema.tagsTable.name })
+        .from(schema.tagsTable)
+        .where(inArray(schema.tagsTable.id, tagIds))
+      ).map((t) => t.name)
+    : []
+
+  const text = buildEmbeddingText({
+    title: recipe.title,
+    tags: tagNames,
+    description: recipe.description,
+    cookingTimeMinutes: recipe.cookingTimeMinutes,
+  })
+
+  const vector = await embed(text, apiKey)
+
+  await vectorSearch.upsert(recipe.id, vector, {
+    tagNames,
+    cookingTimeMinutes: recipe.cookingTimeMinutes ?? 0,
+  })
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,27 +1,34 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "tallriken",
-  "compatibility_date": "2026-04-07",
-  "compatibility_flags": ["nodejs_compat"],
-  "main": "@tanstack/react-start/server-entry",
-  "d1_databases": [
-    {
-      "binding": "DB",
-      "database_name": "tallriken-db",
-      "database_id": "65fbf673-e8ce-499a-af01-ab586e538e26",
-      "migrations_dir": "drizzle"
-    }
-  ],
-  "r2_buckets": [
-    {
-      "binding": "R2",
-      "bucket_name": "tallriken-images"
-    }
-  ],
-  "vectorize": [
-    {
-      "binding": "VECTORIZE",
-      "index_name": "tallriken-recipes"
-    }
-  ]
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "tallriken",
+	"compatibility_date": "2026-04-07",
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
+	"main": "@tanstack/react-start/server-entry",
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "tallriken-db",
+			"database_id": "65fbf673-e8ce-499a-af01-ab586e538e26",
+			"migrations_dir": "drizzle"
+		}
+	],
+	"r2_buckets": [
+		{
+			"binding": "R2",
+			"bucket_name": "tallriken-images"
+		}
+	],
+	"vectorize": [
+		{
+			"binding": "VECTORIZE",
+			"index_name": "tallriken-recipes"
+		},
+		{
+			"binding": "VECTORIZE",
+			"index_name": "tallriken-recipes",
+			"remote": true
+		}
+	]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,5 +17,11 @@
       "binding": "R2",
       "bucket_name": "tallriken-images"
     }
+  ],
+  "vectorize": [
+    {
+      "binding": "VECTORIZE",
+      "index_name": "tallriken-recipes"
+    }
   ]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -24,11 +24,6 @@
 		{
 			"binding": "VECTORIZE",
 			"index_name": "tallriken-recipes"
-		},
-		{
-			"binding": "VECTORIZE",
-			"index_name": "tallriken-recipes",
-			"remote": true
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- Adds a `src/vector/` module with OpenAI `text-embedding-3-small` embeddings and Cloudflare Vectorize for semantic recipe search
- Recipes are embedded on create/update/delete as a structured summary (title | tags | description | cooking time)
- AI chat search uses vector similarity instead of the old dual-search + fuzzy stem matching strategy, with fallback to text search
- Frontend freetext search uses vector search, tag-click/filter-only queries stay on D1
- Tag renames re-embed all affected recipes
- Includes a `triggerBackfill` server function to embed all existing recipes

Closes #46

## Test plan

- [ ] Create Vectorize index: `wrangler vectorize create tallriken-recipes --dimensions=1536 --metric=cosine`
- [ ] Deploy and trigger backfill for existing recipes
- [ ] Test chat queries that previously missed: Swedish word forms ("barnvänliga"), semantic queries ("snabb middag"), ingredient-based queries
- [ ] Test frontend search with freetext
- [ ] Verify tag-click filtering still works (D1 path)
- [ ] Verify recipe create/edit/delete syncs vectors
- [ ] Verify tag rename re-embeds affected recipes