### PR TITLE
Improve vector search and remove tags parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "dev": "vite dev --port 3000",
+    "dev:remote": "vite dev --port 3000 -- --remote",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/scripts/db-sync.sh
+++ b/scripts/db-sync.sh
@@ -6,6 +6,11 @@ LOCAL_DB=".wrangler/state/v3/d1/miniflare-D1DatabaseObject/591bbc95322edaa17f434
 DUMP_FILE="/tmp/tallriken-d1-dump.sql"
 TABLES="tags recipes recipe_tags shopping_lists weekly_menu_items"
 
+# Reverse a space-separated list (macOS lacks tac)
+reverse_tables() {
+  echo "$TABLES" | tr ' ' '\n' | tail -r | tr '\n' ' '
+}
+
 usage() {
   echo "Usage: $0 <local-to-prod|prod-to-local>"
   echo ""
@@ -18,7 +23,8 @@ dump_local() {
   echo "Exporting local D1..."
   rm -f "$DUMP_FILE"
   for table in $TABLES; do
-    sqlite3 "$LOCAL_DB" ".dump $table" >> "$DUMP_FILE"
+    # Export INSERT statements only (no transactions, no schema)
+    sqlite3 "$LOCAL_DB" ".mode insert $table" "SELECT * FROM $table;" >> "$DUMP_FILE"
   done
   echo "Exported to $DUMP_FILE"
 }
@@ -31,7 +37,7 @@ dump_remote() {
 
 import_local() {
   echo "Clearing local tables..."
-  for table in $(echo "$TABLES" | tr ' ' '\n' | tac); do
+  for table in $(reverse_tables); do
     sqlite3 "$LOCAL_DB" "DELETE FROM $table;"
   done
   echo "Importing into local D1..."
@@ -41,7 +47,7 @@ import_local() {
 
 import_remote() {
   echo "Clearing remote tables..."
-  for table in $(echo "$TABLES" | tr ' ' '\n' | tac); do
+  for table in $(reverse_tables); do
     npx wrangler d1 execute "$DB_NAME" --remote --command="DELETE FROM $table;"
   done
   echo "Importing into remote D1..."

--- a/src/chat/recipe-search.ts
+++ b/src/chat/recipe-search.ts
@@ -25,11 +25,21 @@ export type FindSimilar = (query: string) => Promise<{ recipeId: number; score: 
 
 export const createRecipeSearch = (db: Database, findSimilar?: FindSimilar) => ({
   search: async (query: string, filters?: SearchFilters): Promise<CompactRecipeResult[]> => {
+    console.log('[search] query:', query, 'filters:', filters, 'hasVectorSearch:', !!findSimilar)
     if (findSimilar && query) {
-      return vectorSearch(db, findSimilar, query, filters)
+      try {
+        const results = await vectorSearch(db, findSimilar, query, filters)
+        console.log('[search] vector results:', results.length)
+        return results
+      } catch (error) {
+        console.error('[search] vector search failed:', error)
+        return fallbackSearch(db, query, filters)
+      }
     }
 
-    return fallbackSearch(db, query, filters)
+    const results = await fallbackSearch(db, query, filters)
+    console.log('[search] fallback results:', results.length)
+    return results
   },
 })
 

--- a/src/chat/tools.ts
+++ b/src/chat/tools.ts
@@ -21,29 +21,25 @@ const recipeResultSchema = z.object({
 const searchRecipesDef = toolDefinition({
   name: 'search_recipes',
   description:
-    'Sök efter recept i användarens receptsamling. Returnerar recept som matchar sökfrasen med titel, beskrivning, ingredienser, tillagningstid, taggar, antal gånger lagat och senast lagat.',
+    'Sök efter recept i användarens receptsamling med semantisk sökning. Skriv alltid en beskrivande sökfras, t.ex. "snabba barnvänliga rätter" eller "vegetarisk pasta". Returnerar recept rankade efter relevans.',
   inputSchema: z.object({
-    query: z.string().describe('Sökfras (ingrediens, mattitel, typ av rätt etc)'),
+    query: z.string().describe('Beskrivande sökfras på naturligt språk (t.ex. "enkel vegetarisk middag", "barnvänligt under 30 min")'),
     maxCookingTimeMinutes: z
       .number()
       .optional()
       .describe('Max tillagningstid i minuter'),
-    tags: z
-      .array(z.string())
-      .optional()
-      .describe('Filtrera på taggar (t.ex. ["Vegetariskt", "Snabbt"])'),
   }),
   outputSchema: z.array(recipeResultSchema),
 })
 
 export const searchRecipesTool = searchRecipesDef.server(
-  async ({ query, maxCookingTimeMinutes, tags }) => {
+  async ({ query, maxCookingTimeMinutes }) => {
     const db = getDb()
     const vectorSearch = getVectorSearch()
     const search = createRecipeSearch(db, (q) =>
       vectorSearch.findSimilar({ query: q, topK: 15 }),
     )
-    const results = await search.search(query, { maxCookingTimeMinutes, tags })
+    const results = await search.search(query, { maxCookingTimeMinutes })
     return results.map((r) => ({
       ...r,
       lastCookedAt: r.lastCookedAt?.toISOString() ?? null,

--- a/src/routes/api/chat.ts
+++ b/src/routes/api/chat.ts
@@ -9,11 +9,11 @@ import { getAllTags } from '#/tags/crud'
 const SYSTEM_PROMPT = `Du är Tallrikens receptassistent. Du hjälper användaren att hitta recept, planera veckomenyer, skapa inköpslistor och skala recept.
 
 VIKTIGT om sökning:
-- Verktyget search_recipes söker efter recept med sökfras, taggar och max tillagningstid. Resultaten inkluderar cookCount och lastCookedAt.
+- Verktyget search_recipes använder semantisk sökning. Skriv alltid en beskrivande sökfras, t.ex. "snabba barnvänliga rätter" eller "enkel vegetarisk pasta".
 - ALLTID sök med search_recipes INNAN du svarar på frågor om recept. Svara ALDRIG att recept inte finns utan att först ha sökt.
-- När användaren nämner en kategori (t.ex. "barnvänligt", "vegetariskt"), matcha mot de tillgängliga taggarna (listas i slutet av denna prompt) och skicka det EXAKTA taggnamnet i tags-parametern. Lämna query tom vid ren tagg-sökning.
+- Inkludera kategori, önskemål och begränsningar direkt i sökfrasen istället för att använda separata filter.
 - Du kan bedöma kosttyp genom att titta på ingredienserna.
-- Du kan filtrera på tillagningstid, antal portioner, ingredienser etc.
+- Använd maxCookingTimeMinutes-parametern om användaren anger en specifik tidsgräns.
 - Använd cookCount och lastCookedAt för att svara på frågor om matlagningshistorik.
 
 VIKTIGT om veckomenyn:

--- a/src/vector/__tests__/embed.test.ts
+++ b/src/vector/__tests__/embed.test.ts
@@ -7,10 +7,11 @@ describe('buildEmbeddingText', () => {
       title: 'Pasta Carbonara',
       tags: ['Italienskt', 'Snabblagat'],
       description: 'Klassisk krämig pasta',
+      ingredients: ['pasta', 'ägg', 'parmesan', 'pancetta'],
       cookingTimeMinutes: 25,
     })
 
-    expect(result).toBe('Pasta Carbonara | Italienskt, Snabblagat | Klassisk krämig pasta | 25 min')
+    expect(result).toBe('Pasta Carbonara | Italienskt, Snabblagat | Klassisk krämig pasta | pasta, ägg, parmesan, pancetta | 25 min')
   })
 
   it('omits tags when empty', () => {
@@ -18,10 +19,11 @@ describe('buildEmbeddingText', () => {
       title: 'Enkel soppa',
       tags: [],
       description: 'Snabb vardagsmat',
+      ingredients: ['morot', 'lök'],
       cookingTimeMinutes: 15,
     })
 
-    expect(result).toBe('Enkel soppa | Snabb vardagsmat | 15 min')
+    expect(result).toBe('Enkel soppa | Snabb vardagsmat | morot, lök | 15 min')
   })
 
   it('omits description when null', () => {
@@ -29,10 +31,11 @@ describe('buildEmbeddingText', () => {
       title: 'Pannkakor',
       tags: ['Barnvänligt'],
       description: null,
+      ingredients: ['mjöl', 'ägg', 'mjölk'],
       cookingTimeMinutes: 30,
     })
 
-    expect(result).toBe('Pannkakor | Barnvänligt | 30 min')
+    expect(result).toBe('Pannkakor | Barnvänligt | mjöl, ägg, mjölk | 30 min')
   })
 
   it('omits cooking time when null', () => {
@@ -40,10 +43,11 @@ describe('buildEmbeddingText', () => {
       title: 'Sallad',
       tags: ['Lunch'],
       description: 'Fräsch sallad',
+      ingredients: ['sallad', 'tomat'],
       cookingTimeMinutes: null,
     })
 
-    expect(result).toBe('Sallad | Lunch | Fräsch sallad')
+    expect(result).toBe('Sallad | Lunch | Fräsch sallad | sallad, tomat')
   })
 
   it('returns only title when all other fields are empty/null', () => {
@@ -51,9 +55,22 @@ describe('buildEmbeddingText', () => {
       title: 'Smörgås',
       tags: [],
       description: null,
+      ingredients: [],
       cookingTimeMinutes: null,
     })
 
     expect(result).toBe('Smörgås')
+  })
+
+  it('omits ingredients when empty', () => {
+    const result = buildEmbeddingText({
+      title: 'Snabbmat',
+      tags: ['Snabbt'],
+      description: null,
+      ingredients: [],
+      cookingTimeMinutes: 10,
+    })
+
+    expect(result).toBe('Snabbmat | Snabbt | 10 min')
   })
 })

--- a/src/vector/__tests__/sync.test.ts
+++ b/src/vector/__tests__/sync.test.ts
@@ -33,6 +33,7 @@ describe('syncRecipeVector', () => {
       id: 1,
       title: 'Pasta Carbonara',
       description: 'Klassisk pasta',
+      ingredients: [{ group: null, items: ['pasta', 'ägg'] }],
       cookingTimeMinutes: 25,
     }, [tag.id])
 
@@ -51,6 +52,7 @@ describe('syncRecipeVector', () => {
       id: 2,
       title: 'Enkel soppa',
       description: null,
+      ingredients: [],
       cookingTimeMinutes: null,
     }, [])
 
@@ -71,6 +73,7 @@ describe('syncRecipeVector', () => {
       id: 3,
       title: 'Pannkakor',
       description: 'Snabba pannkakor',
+      ingredients: [{ group: null, items: ['mjöl', 'ägg', 'mjölk'] }],
       cookingTimeMinutes: 15,
     }, [tag1.id, tag2.id])
 

--- a/src/vector/embed.ts
+++ b/src/vector/embed.ts
@@ -4,6 +4,7 @@ type EmbeddingInput = {
   title: string
   tags: string[]
   description: string | null
+  ingredients: string[]
   cookingTimeMinutes: number | null
 }
 
@@ -16,6 +17,10 @@ export const buildEmbeddingText = (recipe: EmbeddingInput): string => {
 
   if (recipe.description) {
     parts.push(recipe.description)
+  }
+
+  if (recipe.ingredients.length > 0) {
+    parts.push(recipe.ingredients.join(', '))
   }
 
   if (recipe.cookingTimeMinutes != null) {

--- a/src/vector/sync.ts
+++ b/src/vector/sync.ts
@@ -8,6 +8,7 @@ type SyncRecipe = {
   id: number
   title: string
   description: string | null
+  ingredients: { group: string | null; items: string[] }[]
   cookingTimeMinutes: number | null
 }
 
@@ -30,6 +31,7 @@ export const syncRecipeVector = async (
     title: recipe.title,
     tags: tagNames,
     description: recipe.description,
+    ingredients: recipe.ingredients.flatMap((g) => g.items),
     cookingTimeMinutes: recipe.cookingTimeMinutes,
   })
 


### PR DESCRIPTION
## Summary

- Include ingredient names in embedding text so searches like "pasta" find recipes with pasta as an ingredient
- Remove `tags` parameter from search tool -- vector search handles categories via freetext instead
- Update system prompt to guide the AI toward descriptive search phrases
- Add error logging and fallback when vector search fails
- Add `dev:remote` npm script

## Test plan

- [ ] Run backfill from /admin/vectors after deploy
- [ ] Test "pastarecept" finds Carbonara (ingredient-based match)
- [ ] Test "barnvänliga recept" still works (tag-based match via embeddings)
- [ ] Test structured queries like "snabb vegetarisk middag"