### PR TITLE
Clean up import pipeline: dedup prompts and extract tag classification

### DIFF
--- a/src/import/__tests__/pipeline.test.ts
+++ b/src/import/__tests__/pipeline.test.ts
@@ -28,6 +28,7 @@ const createTestDeps = (overrides: Partial<ImportDeps> = {}): ImportDeps => ({
   openaiApiKey: "unused",
   fetchHtml: async () => "",
   extractWithAi: async () => null,
+  classifyTags: async () => [],
   storeImage: async () => null,
   ...overrides,
 });
@@ -147,37 +148,31 @@ describe("importRecipe", () => {
     expect(result.tagIds).toHaveLength(2);
   });
 
-  it("calls AI for tag classification when JSON-LD has no suggested tags", async () => {
+  it("calls classifyTags for tag classification when JSON-LD has no suggested tags", async () => {
     const db = createTestDb();
     const fisk = await createTestTag(db, "Fisk");
     await createTestTag(db, "Dessert");
 
-    let aiCallCount = 0;
+    let classifyCallCount = 0;
 
     const result = await importRecipe(
       { kind: "url", url: "https://example.com/salmon" },
       createTestDeps({
         db,
         fetchHtml: async () => JSON_LD_HTML,
-        extractWithAi: async () => {
-          aiCallCount++;
-          // AI is called only for tag classification, returns draft with tag suggestions
-          return {
-            title: "ignored",
-            description: null,
-            ingredients: [{ group: null, items: ["ignored"] }],
-            steps: null,
-            cookingTimeMinutes: null,
-            servings: null,
-            suggestedTagNames: ["Fisk"],
-          };
+        classifyTags: async (recipe, tagNames) => {
+          classifyCallCount++;
+          expect(recipe.title).toBe("Pannkakor");
+          expect(recipe.ingredients).toEqual(["3 dl mjöl", "6 dl mjölk", "3 ägg"]);
+          expect(tagNames).toEqual(expect.arrayContaining(["Fisk", "Dessert"]));
+          return ["Fisk"];
         },
       }),
     );
 
     expect(result.extraction).toBe("json-ld");
     expect(result.draft.title).toBe("Pannkakor");
-    expect(aiCallCount).toBe(1);
+    expect(classifyCallCount).toBe(1);
     expect(result.tagIds).toEqual([fisk.id]);
   });
 

--- a/src/import/ai-extract.ts
+++ b/src/import/ai-extract.ts
@@ -2,25 +2,13 @@ import OpenAI from 'openai'
 import { zodResponseFormat } from 'openai/helpers/zod'
 import { recipeDraftSchema, type RecipeDraft } from '#/import/schema'
 import { cleanHtmlForExtraction } from '#/import/html-cleaner'
+import { buildExtractionPrompt } from '#/import/prompts'
 
-const buildSystemPrompt = (tagNames: string[]) => {
-  const tagSection = tagNames.length > 0
-    ? `\n\nTillgängliga taggar att välja bland: ${tagNames.join(', ')}\nVälj de taggar som passar receptet bäst och returnera dem i fältet "suggestedTagNames". Välj bara taggar från listan ovan.`
-    : ''
-
-  return `Du är en receptextraherare. Du får textinnehåll extraherat från en receptsajt och ska extrahera receptet till ett strukturerat format på svenska.
-
-Regler:
-- Extrahera ALLA ingredienser, inte bara några. Var noggrann.
-- Ingredienser ska grupperas om receptet har underrubriker (t.ex. "Deg", "Fyllning", "Sås"). Varje grupp har ett "group"-fält (gruppnamn eller null om ingen grupp) och "items" (lista med ingredienser).
-- Om receptet inte har grupperade ingredienser, använd en enda grupp med group: null.
-- Extrahera ALLA tillagningssteg i ordning. Var noggrann.
-- Steg ska vara en lista med strängar, ett per steg
-- Tillagningstid i minuter som heltal
-- Portioner som heltal
-- Om informationen saknas, sätt fältet till null
-- Svara alltid på svenska${tagSection}`
-}
+const buildSystemPrompt = (tagNames: string[]) =>
+  buildExtractionPrompt(
+    'Du är en receptextraherare. Du får textinnehåll extraherat från en receptsajt och ska extrahera receptet till ett strukturerat format på svenska.',
+    tagNames,
+  )
 
 export const extractRecipeWithAi = async (
   html: string,

--- a/src/import/ocr-extract.ts
+++ b/src/import/ocr-extract.ts
@@ -1,31 +1,18 @@
 import OpenAI from 'openai'
 import { zodResponseFormat } from 'openai/helpers/zod'
 import { recipeDraftSchema, type RecipeDraft } from '#/import/schema'
+import { buildExtractionPrompt } from '#/import/prompts'
 
 type ImageInput = {
   base64: string
   mimeType: string
 }
 
-const buildSystemPrompt = (tagNames: string[]) => {
-  const tagSection = tagNames.length > 0
-    ? `\n\nTillgängliga taggar att välja bland: ${tagNames.join(', ')}\nVälj de taggar som passar receptet bäst och returnera dem i fältet "suggestedTagNames". Välj bara taggar från listan ovan.`
-    : ''
-
-  return `Du är en receptextraherare. Du får en eller flera bilder av en kokbokssida och ska extrahera receptet till ett strukturerat format på svenska.
-
-Regler:
-- Extrahera ALLA ingredienser, inte bara några. Var noggrann.
-- Ingredienser ska grupperas om receptet har underrubriker (t.ex. "Deg", "Fyllning", "Sås"). Varje grupp har ett "group"-fält (gruppnamn eller null om ingen grupp) och "items" (lista med ingredienser).
-- Om receptet inte har grupperade ingredienser, använd en enda grupp med group: null.
-- Extrahera ALLA tillagningssteg i ordning. Var noggrann.
-- Steg ska vara en lista med strängar, ett per steg
-- Tillagningstid i minuter som heltal
-- Portioner som heltal
-- Om flera bilder skickas tillhör de samma recept (t.ex. ett uppslag i en kokbok)
-- Om informationen saknas, sätt fältet till null
-- Svara alltid på svenska${tagSection}`
-}
+const buildSystemPrompt = (tagNames: string[]) =>
+  buildExtractionPrompt(
+    'Du är en receptextraherare. Du får en eller flera bilder av en kokbokssida och ska extrahera receptet till ett strukturerat format på svenska.\n\nOm flera bilder skickas tillhör de samma recept (t.ex. ett uppslag i en kokbok).',
+    tagNames,
+  )
 
 export const extractRecipeFromImages = async (
   images: ImageInput[],

--- a/src/import/pipeline.ts
+++ b/src/import/pipeline.ts
@@ -11,6 +11,12 @@ export type AiExtractionInput =
   | { kind: "html"; html: string }
   | { kind: "images"; images: Array<{ base64: string; mimeType: string }> };
 
+export type ClassifyTagsInput = {
+  title: string;
+  description: string | null;
+  ingredients: string[];
+};
+
 export type ImportDeps = {
   db: Database;
   openaiApiKey: string;
@@ -19,6 +25,10 @@ export type ImportDeps = {
     input: AiExtractionInput,
     tagNames: string[],
   ) => Promise<RecipeDraft | null>;
+  classifyTags?: (
+    recipe: ClassifyTagsInput,
+    tagNames: string[],
+  ) => Promise<string[]>;
   storeImage?: (url: string) => Promise<string | null>;
 };
 
@@ -48,6 +58,8 @@ const importFromUrl = async (
   const fetchHtml = deps.fetchHtml ?? defaultFetchHtml;
   const extractWithAi =
     deps.extractWithAi ?? defaultExtractWithAi(deps.openaiApiKey);
+  const classifyTags =
+    deps.classifyTags ?? defaultClassifyTags(deps.openaiApiKey);
   const storeImage = deps.storeImage ?? defaultStoreImage;
 
   const tags = await getAllTags(deps.db);
@@ -57,7 +69,7 @@ const importFromUrl = async (
 
   const jsonLdDraft = extractJsonLdRecipe(html);
   if (jsonLdDraft) {
-    const tagIds = await resolveTagIds(jsonLdDraft, tags, extractWithAi);
+    const tagIds = await resolveTagIds(jsonLdDraft, tags, classifyTags);
     const imageUrl = await resolveImageUrl(html, storeImage);
     return {
       draft: jsonLdDraft,
@@ -70,7 +82,7 @@ const importFromUrl = async (
 
   const aiDraft = await extractWithAi({ kind: "html", html }, tagNames);
   if (aiDraft) {
-    const tagIds = await resolveTagIds(aiDraft, tags, extractWithAi);
+    const tagIds = await resolveTagIds(aiDraft, tags, classifyTags);
     const imageUrl = await resolveImageUrl(html, storeImage);
     return {
       draft: aiDraft,
@@ -99,10 +111,10 @@ const matchTagNames = (
 const resolveTagIds = async (
   draft: RecipeDraft,
   tags: Array<{ id: number; name: string }>,
-  extractWithAi: (
-    input: AiExtractionInput,
+  classifyTags: (
+    recipe: ClassifyTagsInput,
     tagNames: string[],
-  ) => Promise<RecipeDraft | null>,
+  ) => Promise<string[]>,
 ): Promise<number[]> => {
   if (draft.suggestedTagNames && draft.suggestedTagNames.length > 0) {
     return matchTagNames(draft.suggestedTagNames, tags);
@@ -114,14 +126,15 @@ const resolveTagIds = async (
   try {
     const tagNames = tags.map((t) => t.name);
     const allItems = draft.ingredients.flatMap((g) => g.items);
-    const summaryHtml = `<title>${draft.title}</title><p>${draft.description ?? ""}</p><ul>${allItems.map((i) => `<li>${i}</li>`).join("")}</ul>`;
-    const aiDraft = await extractWithAi(
-      { kind: "html", html: summaryHtml },
+    const suggestedNames = await classifyTags(
+      {
+        title: draft.title,
+        description: draft.description ?? null,
+        ingredients: allItems,
+      },
       tagNames,
     );
-    if (aiDraft?.suggestedTagNames) {
-      return matchTagNames(aiDraft.suggestedTagNames, tags);
-    }
+    return matchTagNames(suggestedNames, tags);
   } catch {
     // AI tagging failed, continue without tags
   }
@@ -135,6 +148,8 @@ const importFromPhotos = async (
 ): Promise<ImportResult> => {
   const extractWithAi =
     deps.extractWithAi ?? defaultExtractWithAi(deps.openaiApiKey);
+  const classifyTags =
+    deps.classifyTags ?? defaultClassifyTags(deps.openaiApiKey);
 
   const tags = await getAllTags(deps.db);
   const tagNames = tags.map((t) => t.name);
@@ -145,7 +160,7 @@ const importFromPhotos = async (
     throw new Error("Kunde inte extrahera något recept från bilderna");
   }
 
-  const tagIds = await resolveTagIds(draft, tags, extractWithAi);
+  const tagIds = await resolveTagIds(draft, tags, classifyTags);
 
   return {
     draft,
@@ -181,6 +196,45 @@ const defaultExtractWithAi =
     }
     const { extractRecipeFromImages } = await import("#/import/ocr-extract");
     return extractRecipeFromImages(input.images, tagNames, apiKey);
+  };
+
+const defaultClassifyTags =
+  (apiKey: string) =>
+  async (
+    recipe: ClassifyTagsInput,
+    tagNames: string[],
+  ): Promise<string[]> => {
+    const OpenAI = (await import("openai")).default;
+    const client = new OpenAI({ apiKey });
+
+    const ingredientList = recipe.ingredients.join(", ");
+    const description = recipe.description ?? "";
+
+    const completion = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content: `Du är en receptklassificerare. Givet ett recepts titel, beskrivning och ingredienser, välj de taggar som passar bäst från listan.\n\nSvara med en JSON-array av strängar, t.ex. ["Fisk", "Vardag"]. Välj bara taggar från listan. Om inga taggar passar, svara med en tom array [].`,
+        },
+        {
+          role: "user",
+          content: `Recept: ${recipe.title}\nBeskrivning: ${description}\nIngredienser: ${ingredientList}\n\nTillgängliga taggar: ${tagNames.join(", ")}`,
+        },
+      ],
+      response_format: { type: "json_object" },
+    });
+
+    const content = completion.choices[0].message.content;
+    if (!content) return [];
+
+    try {
+      const parsed = JSON.parse(content);
+      const tags = Array.isArray(parsed) ? parsed : parsed.tags ?? [];
+      return tags.filter((t: unknown): t is string => typeof t === "string");
+    } catch {
+      return [];
+    }
   };
 
 const defaultFetchHtml = async (url: string): Promise<string> => {

--- a/src/import/prompts.ts
+++ b/src/import/prompts.ts
@@ -1,0 +1,20 @@
+const buildTagSection = (tagNames: string[]) =>
+  tagNames.length > 0
+    ? `\n\nTillgängliga taggar att välja bland: ${tagNames.join(', ')}\nVälj de taggar som passar receptet bäst och returnera dem i fältet "suggestedTagNames". Välj bara taggar från listan ovan.`
+    : ''
+
+const sharedRules = `Regler:
+- Extrahera ALLA ingredienser, inte bara några. Var noggrann.
+- Ingredienser ska grupperas om receptet har underrubriker (t.ex. "Deg", "Fyllning", "Sås"). Varje grupp har ett "group"-fält (gruppnamn eller null om ingen grupp) och "items" (lista med ingredienser).
+- Om receptet inte har grupperade ingredienser, använd en enda grupp med group: null.
+- Extrahera ALLA tillagningssteg i ordning. Var noggrann.
+- Steg ska vara en lista med strängar, ett per steg
+- Tillagningstid i minuter som heltal
+- Portioner som heltal
+- Om informationen saknas, sätt fältet till null
+- Svara alltid på svenska`
+
+export const buildExtractionPrompt = (
+  contextParagraph: string,
+  tagNames: string[],
+) => `${contextParagraph}\n\n${sharedRules}${buildTagSection(tagNames)}`


### PR DESCRIPTION
## Summary

- Extracted shared extraction rules from `ai-extract.ts` and `ocr-extract.ts` into `src/import/prompts.ts` (`buildExtractionPrompt`). Each file now passes only its specific context paragraph.
- Replaced the `resolveTagIds` workaround that built fake HTML and called `extractWithAi` for tag classification. Added a proper `classifyTags` dependency on `ImportDeps` with a focused `gpt-4o-mini` call that only does tag classification.
- Updated pipeline tests to use the new `classifyTags` dep with better assertions (verifies recipe data is passed correctly).

Closes #90

## Test plan

- [x] All 125 existing tests pass
- [ ] Manual test: import a recipe via URL (JSON-LD path) and verify tags are suggested
- [ ] Manual test: import a recipe via URL (AI extraction path) and verify tags are suggested
- [ ] Manual test: import a recipe via photos and verify tags are suggested