### PR TITLE
Quick wins batch: indexes, bug fixes, cleanup

### DIFF
--- a/drizzle/0005_glamorous_lady_ursula.sql
+++ b/drizzle/0005_glamorous_lady_ursula.sql
@@ -1,0 +1,2 @@
+CREATE INDEX `idx_recipe_tags_recipe_id` ON `recipe_tags` (`recipe_id`);--> statement-breakpoint
+CREATE INDEX `idx_recipe_tags_tag_id` ON `recipe_tags` (`tag_id`);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,301 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5eb96aeb-e8ad-4918-bcd3-9e57b8a134e2",
+  "prevId": "256c6671-84d4-4543-a66f-222d6001aa68",
+  "tables": {
+    "recipe_tags": {
+      "name": "recipe_tags",
+      "columns": {
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_recipe_tags_recipe_id": {
+          "name": "idx_recipe_tags_recipe_id",
+          "columns": [
+            "recipe_id"
+          ],
+          "isUnique": false
+        },
+        "idx_recipe_tags_tag_id": {
+          "name": "idx_recipe_tags_tag_id",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recipe_tags_recipe_id_recipes_id_fk": {
+          "name": "recipe_tags_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_tags",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_tags_tag_id_tags_id_fk": {
+          "name": "recipe_tags_tag_id_tags_id_fk",
+          "tableFrom": "recipe_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipes": {
+      "name": "recipes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingredients": {
+          "name": "ingredients",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cooking_time_minutes": {
+          "name": "cooking_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "servings": {
+          "name": "servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_cooked_at": {
+          "name": "last_cooked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cook_count": {
+          "name": "cook_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shopping_lists": {
+      "name": "shopping_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weekly_menu_items": {
+      "name": "weekly_menu_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weekly_menu_items_recipe_id_recipes_id_fk": {
+          "name": "weekly_menu_items_recipe_id_recipes_id_fk",
+          "tableFrom": "weekly_menu_items",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1775720008751,
       "tag": "0004_bent_shadowcat",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1775828061449,
+      "tag": "0005_glamorous_lady_ursula",
+      "breakpoints": true
     }
   ]
 }

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto'
 
-export const SESSION_DURATION_SECONDS = 30 * 24 * 60 * 60 // 30 days
+export const SESSION_DURATION_SECONDS = 30 * 24 * 60 * 60
 
 export const createSessionToken = (secret: string): string => {
   const expiresAt = Date.now() + SESSION_DURATION_SECONDS * 1000

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -1,0 +1,30 @@
+import { useCopyToClipboard } from '#/hooks/use-copy-to-clipboard'
+import { ClipboardDocumentIcon, CheckIcon } from '@heroicons/react/24/outline'
+
+type CopyButtonProps = {
+  text: string
+  className?: string
+}
+
+export const CopyButton = ({ text, className }: CopyButtonProps) => {
+  const { copied, copy } = useCopyToClipboard()
+
+  return (
+    <button
+      onClick={() => copy(text)}
+      className={className ?? 'flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium text-gray-400 transition hover:bg-gray-100 hover:text-gray-600'}
+    >
+      {copied ? (
+        <>
+          <CheckIcon className="h-3.5 w-3.5 text-green-500" />
+          Kopierat
+        </>
+      ) : (
+        <>
+          <ClipboardDocumentIcon className="h-3.5 w-3.5" />
+          Kopiera
+        </>
+      )}
+    </button>
+  )
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 export const tagsTable = sqliteTable('tags', {
   id: integer('id').primaryKey({ autoIncrement: true }),
@@ -32,7 +32,10 @@ export const recipeTagsTable = sqliteTable('recipe_tags', {
   tagId: integer('tag_id')
     .notNull()
     .references(() => tagsTable.id, { onDelete: 'cascade' }),
-})
+}, (table) => [
+  index('idx_recipe_tags_recipe_id').on(table.recipeId),
+  index('idx_recipe_tags_tag_id').on(table.tagId),
+])
 
 export const shoppingListsTable = sqliteTable('shopping_lists', {
   id: integer('id').primaryKey({ autoIncrement: true }),

--- a/src/import/__tests__/extract.test.ts
+++ b/src/import/__tests__/extract.test.ts
@@ -83,6 +83,25 @@ const HTML_WITH_ARRAY_JSON_LD = `
 </html>
 `
 
+const HTML_WITH_ARRAY_TYPE = `
+<html>
+<head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": ["Recipe", "HowTo"],
+  "name": "Köttbullar",
+  "recipeIngredient": ["500g blandfärs", "1 ägg", "1 dl ströbröd"],
+  "recipeInstructions": [{"@type": "HowToStep", "text": "Blanda ihop allt"}],
+  "totalTime": "PT30M",
+  "recipeYield": "4"
+}
+</script>
+</head>
+<body></body>
+</html>
+`
+
 describe('extractJsonLdRecipe', () => {
   it('extracts recipe from HTML with JSON-LD', () => {
     const result = extractJsonLdRecipe(HTML_WITH_RECIPE_JSON_LD)
@@ -111,6 +130,15 @@ describe('extractJsonLdRecipe', () => {
   it('returns null for malformed JSON-LD', () => {
     const result = extractJsonLdRecipe(HTML_WITH_MALFORMED_JSON_LD)
     expect(result).toBeNull()
+  })
+
+  it('handles @type as array', () => {
+    const result = extractJsonLdRecipe(HTML_WITH_ARRAY_TYPE)
+
+    expect(result).not.toBeNull()
+    expect(result!.title).toBe('Köttbullar')
+    expect(result!.cookingTimeMinutes).toBe(30)
+    expect(result!.servings).toBe(4)
   })
 
   it('finds recipe in JSON-LD array', () => {

--- a/src/import/__tests__/ocr-extract.test.ts
+++ b/src/import/__tests__/ocr-extract.test.ts
@@ -50,7 +50,6 @@ describe('extractRecipeFromImages', () => {
     expect(result!.steps).toEqual(['Vispa ihop smeten', 'Stek i smör'])
     expect(result!.suggestedTagNames).toEqual(['Snabblagat'])
 
-    // Verify images were sent as content parts
     expect(parseMock).toHaveBeenCalledOnce()
     const callArgs = parseMock.mock.calls[0][0]
     const userMessage = callArgs.messages.find((m: { role: string }) => m.role === 'user')

--- a/src/import/ai-extract.ts
+++ b/src/import/ai-extract.ts
@@ -19,7 +19,6 @@ export const extractRecipeWithAi = async (
 
   const cleanedText = cleanHtmlForExtraction(html)
 
-  // Begränsa storleken för att undvika att spränga token-gränsen
   const trimmedText = cleanedText.slice(0, 30000)
 
   const completion = await client.chat.completions.parse({

--- a/src/import/extract.ts
+++ b/src/import/extract.ts
@@ -52,7 +52,8 @@ const findRecipeInJsonLd = (data: unknown): Record<string, unknown> | null => {
 
   const obj = data as Record<string, unknown>
 
-  if (obj['@type'] === 'Recipe') return obj
+  const type = obj['@type']
+  if (type === 'Recipe' || (Array.isArray(type) && type.includes('Recipe'))) return obj
 
   if (obj['@graph'] && Array.isArray(obj['@graph'])) {
     return findRecipeInJsonLd(obj['@graph'])
@@ -62,7 +63,6 @@ const findRecipeInJsonLd = (data: unknown): Record<string, unknown> | null => {
 }
 
 export const extractImageUrl = (html: string): string | null => {
-  // Try JSON-LD first
   const jsonLdMatches = [...html.matchAll(JSON_LD_REGEX)]
   for (const match of jsonLdMatches) {
     try {
@@ -79,7 +79,6 @@ export const extractImageUrl = (html: string): string | null => {
     }
   }
 
-  // Fallback: Open Graph image
   const ogMatch = html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i)
     ?? html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:image["']/i)
   if (ogMatch?.[1]) return ogMatch[1]

--- a/src/import/pipeline.ts
+++ b/src/import/pipeline.ts
@@ -135,9 +135,7 @@ const resolveTagIds = async (
       tagNames,
     );
     return matchTagNames(suggestedNames, tags);
-  } catch {
-    // AI tagging failed, continue without tags
-  }
+  } catch {}
 
   return [];
 };

--- a/src/recipes/__tests__/cooking-stats.test.ts
+++ b/src/recipes/__tests__/cooking-stats.test.ts
@@ -47,10 +47,11 @@ describe('cooking stats', () => {
     expect(updated!.cookCount).toBe(0)
   })
 
-  it('does not clear lastCookedAt when undoing', async () => {
+  it('preserves lastCookedAt when cookCount stays above zero', async () => {
     const db = createTestDb()
     const recipe = await createTestRecipe(db, { title: 'Pasta' })
 
+    await recordCooked(db, recipe.id)
     await recordCooked(db, recipe.id)
     const afterCook = await getRecipeById(db, recipe.id)
     const lastCookedAt = afterCook!.lastCookedAt
@@ -58,6 +59,19 @@ describe('cooking stats', () => {
     await undoCooked(db, recipe.id)
 
     const updated = await getRecipeById(db, recipe.id)
+    expect(updated!.cookCount).toBe(1)
     expect(updated!.lastCookedAt).toEqual(lastCookedAt)
+  })
+
+  it('clears lastCookedAt when cookCount reaches zero', async () => {
+    const db = createTestDb()
+    const recipe = await createTestRecipe(db, { title: 'Pasta' })
+
+    await recordCooked(db, recipe.id)
+    await undoCooked(db, recipe.id)
+
+    const updated = await getRecipeById(db, recipe.id)
+    expect(updated!.cookCount).toBe(0)
+    expect(updated!.lastCookedAt).toBeNull()
   })
 })

--- a/src/recipes/cooking-stats.ts
+++ b/src/recipes/cooking-stats.ts
@@ -17,6 +17,7 @@ export const undoCooked = async (db: Database, recipeId: number) => {
     .update(schema.recipesTable)
     .set({
       cookCount: sql`MAX(${schema.recipesTable.cookCount} - 1, 0)`,
+      lastCookedAt: sql`CASE WHEN ${schema.recipesTable.cookCount} <= 1 THEN NULL ELSE ${schema.recipesTable.lastCookedAt} END`,
     })
     .where(eq(schema.recipesTable.id, recipeId))
 }

--- a/src/recipes/search.ts
+++ b/src/recipes/search.ts
@@ -105,7 +105,6 @@ const resolveTagsParam = async (db: Database, tags?: string[] | number[]): Promi
   // If already numeric IDs, return directly
   if (typeof tags[0] === 'number') return tags as number[]
 
-  // Resolve string tag names to IDs
   return resolveTagNames(db, tags as string[])
 }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,6 +4,36 @@ import { ChatToggle } from '#/chat/chat-toggle'
 import { useChatStore } from '#/chat/store'
 import appCss from '../styles.css?url'
 
+const RootDocument = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <html lang="sv">
+      <head>
+        <HeadContent />
+      </head>
+      <body className="min-h-screen font-sans text-gray-800 antialiased">
+        {children}
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+
+const RootComponent = () => {
+  const isOpen = useChatStore((s) => s.isOpen)
+
+  return (
+    <>
+      <div
+        className={`transition-all duration-300 ${isOpen ? 'md:mr-[420px]' : ''}`}
+      >
+        <Outlet />
+      </div>
+      <ChatPanel />
+      <ChatToggle />
+    </>
+  )
+}
+
 export const Route = createRootRoute({
   head: () => ({
     meta: [
@@ -19,33 +49,3 @@ export const Route = createRootRoute({
   shellComponent: RootDocument,
   component: RootComponent,
 })
-
-function RootDocument({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="sv">
-      <head>
-        <HeadContent />
-      </head>
-      <body className="min-h-screen font-sans text-gray-800 antialiased">
-        {children}
-        <Scripts />
-      </body>
-    </html>
-  )
-}
-
-function RootComponent() {
-  const isOpen = useChatStore((s) => s.isOpen)
-
-  return (
-    <>
-      <div
-        className={`transition-all duration-300 ${isOpen ? 'md:mr-[420px]' : ''}`}
-      >
-        <Outlet />
-      </div>
-      <ChatPanel />
-      <ChatToggle />
-    </>
-  )
-}

--- a/src/routes/_authed/admin/tags.tsx
+++ b/src/routes/_authed/admin/tags.tsx
@@ -11,13 +11,7 @@ import {
   TrashIcon,
 } from '@heroicons/react/24/outline'
 
-export const Route = createFileRoute('/_authed/admin/tags')({
-  loader: () => fetchAllTags(),
-  head: () => ({ meta: [{ title: 'Taggar | Tallriken' }] }),
-  component: TagsAdminPage,
-})
-
-function TagsAdminPage() {
+const TagsAdminPage = () => {
   const tags = Route.useLoaderData()
   const [newTagName, setNewTagName] = useState('')
   const [editingId, setEditingId] = useState<number | null>(null)
@@ -155,3 +149,9 @@ function TagsAdminPage() {
     </div>
   )
 }
+
+export const Route = createFileRoute('/_authed/admin/tags')({
+  loader: () => fetchAllTags(),
+  head: () => ({ meta: [{ title: 'Taggar | Tallriken' }] }),
+  component: TagsAdminPage,
+})

--- a/src/routes/_authed/admin/vectors.tsx
+++ b/src/routes/_authed/admin/vectors.tsx
@@ -8,12 +8,7 @@ import {
   ArrowPathIcon,
 } from '@heroicons/react/24/outline'
 
-export const Route = createFileRoute('/_authed/admin/vectors')({
-  head: () => ({ meta: [{ title: 'Vektorsök | Tallriken' }] }),
-  component: VectorsAdminPage,
-})
-
-function VectorsAdminPage() {
+const VectorsAdminPage = () => {
   const [showConfirm, setShowConfirm] = useState(false)
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
   const [result, setResult] = useState<string | null>(null)
@@ -86,3 +81,8 @@ function VectorsAdminPage() {
     </div>
   )
 }
+
+export const Route = createFileRoute('/_authed/admin/vectors')({
+  head: () => ({ meta: [{ title: 'Vektorsök | Tallriken' }] }),
+  component: VectorsAdminPage,
+})

--- a/src/routes/_authed/import.tsx
+++ b/src/routes/_authed/import.tsx
@@ -10,15 +10,9 @@ import { RecipeForm, TabButton, type RecipeFormData } from '#/components/recipe-
 import { fileToBase64 } from '#/utils/file'
 import { ArrowLeftIcon } from '@heroicons/react/24/outline'
 
-export const Route = createFileRoute('/_authed/import')({
-  loader: () => fetchAllTags(),
-  head: () => ({ meta: [{ title: 'Nytt recept | Tallriken' }] }),
-  component: ImportPage,
-})
-
 type ImportTab = 'url' | 'photo' | 'manual'
 
-function ImportPage() {
+const ImportPage = () => {
   const tags = Route.useLoaderData()
   const navigate = useNavigate()
   const [tab, setTab] = useState<ImportTab>('url')
@@ -236,3 +230,9 @@ const PhotoImport = ({ onExtracted, onError }: PhotoImportProps) => {
     </div>
   )
 }
+
+export const Route = createFileRoute('/_authed/import')({
+  loader: () => fetchAllTags(),
+  head: () => ({ meta: [{ title: 'Nytt recept | Tallriken' }] }),
+  component: ImportPage,
+})

--- a/src/routes/_authed/index.tsx
+++ b/src/routes/_authed/index.tsx
@@ -24,20 +24,6 @@ import {
   ArrowRightStartOnRectangleIcon,
 } from '@heroicons/react/24/outline'
 
-export const Route = createFileRoute('/_authed/')({
-  loader: async () => {
-    const [recipes, tags, menuRecipeIds, favorites, stale] = await Promise.all([
-      fetchAllRecipes(),
-      fetchAllTags(),
-      fetchMenuRecipeIds(),
-      fetchFavoriteRecipes(),
-      fetchStaleRecipes(),
-    ])
-    return { recipes, tags, menuRecipeIds, favorites, stale }
-  },
-  component: HomePage,
-})
-
 type CookingInsightsProps = {
   favorites: { id: number; title: string; cookCount: number }[]
   stale: { id: number; title: string; lastCookedAt: Date | null }[]
@@ -98,7 +84,7 @@ const CookingInsights = ({ favorites, stale }: CookingInsightsProps) => {
   )
 }
 
-function HomePage() {
+const HomePage = () => {
   const { recipes: initialRecipes, tags, menuRecipeIds: initialMenuIds, favorites, stale } = Route.useLoaderData()
   const setPageContext = useChatStore((s) => s.setPageContext)
   const [recipes, setRecipes] = useState(initialRecipes)
@@ -304,3 +290,17 @@ function HomePage() {
     </div>
   )
 }
+
+export const Route = createFileRoute('/_authed/')({
+  loader: async () => {
+    const [recipes, tags, menuRecipeIds, favorites, stale] = await Promise.all([
+      fetchAllRecipes(),
+      fetchAllTags(),
+      fetchMenuRecipeIds(),
+      fetchFavoriteRecipes(),
+      fetchStaleRecipes(),
+    ])
+    return { recipes, tags, menuRecipeIds, favorites, stale }
+  },
+  component: HomePage,
+})

--- a/src/routes/_authed/recipes/$recipeId.tsx
+++ b/src/routes/_authed/recipes/$recipeId.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useState, useEffect } from 'react'
 import { useChatStore } from '#/chat/store'
-import { useCopyToClipboard } from '#/hooks/use-copy-to-clipboard'
+import { CopyButton } from '#/components/copy-button'
 import { fetchRecipeById, removeRecipe } from '#/recipes/server'
 import { generateAndSaveImage, uploadImageForRecipe } from '#/images/server'
 import { fetchMenuRecipeIds, addRecipeToMenu, removeRecipeFromMenu } from '#/menu/server'
@@ -19,34 +19,16 @@ import {
   ClockIcon,
   UsersIcon,
   ArrowTopRightOnSquareIcon,
-  ClipboardDocumentIcon,
-  CheckIcon,
   CalendarIcon,
   PencilSquareIcon,
   TrashIcon,
   EllipsisVerticalIcon,
 } from '@heroicons/react/24/outline'
 
-export const Route = createFileRoute('/_authed/recipes/$recipeId')({
-  loader: async ({ params }) => {
-    const [recipe, menuRecipeIds] = await Promise.all([
-      fetchRecipeById({ data: { id: parseInt(params.recipeId, 10) } }),
-      fetchMenuRecipeIds(),
-    ])
-    if (!recipe) {
-      throw new Error('Receptet hittades inte')
-    }
-    return { recipe, menuRecipeIds }
-  },
-  head: ({ loaderData }) => ({ meta: [{ title: `${loaderData.recipe.title} | Tallriken` }] }),
-  component: RecipeDetailPage,
-})
-
-function RecipeDetailPage() {
+const RecipeDetailPage = () => {
   const { recipe, menuRecipeIds } = Route.useLoaderData()
   const navigate = useNavigate()
   const setPageContext = useChatStore((s) => s.setPageContext)
-  const { copied, copy: copyToClipboard } = useCopyToClipboard()
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [currentImageUrl, setCurrentImageUrl] = useState(recipe.imageUrl)
   const [inMenu, setInMenu] = useState(menuRecipeIds.includes(recipe.id))
@@ -56,15 +38,12 @@ function RecipeDetailPage() {
     return () => setPageContext({ type: 'other' })
   }, [recipe.id, recipe.title, setPageContext])
 
-  const handleCopyIngredients = async () => {
-    const text = recipe.ingredients
-      .map((g) => {
-        const header = g.group ? `${g.group}\n` : ''
-        return header + g.items.join('\n')
-      })
-      .join('\n\n')
-    await copyToClipboard(text)
-  }
+  const ingredientsText = recipe.ingredients
+    .map((g) => {
+      const header = g.group ? `${g.group}\n` : ''
+      return header + g.items.join('\n')
+    })
+    .join('\n\n')
 
   const handleGenerateImage = async (): Promise<string> => {
     const result = await generateAndSaveImage({ data: { recipeId: recipe.id } })
@@ -190,22 +169,7 @@ function RecipeDetailPage() {
           <section>
             <div className="flex items-center justify-between">
               <h2 className="text-sm font-bold uppercase tracking-wide text-gray-400">Ingredienser</h2>
-              <button
-                onClick={handleCopyIngredients}
-                className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
-              >
-                {copied ? (
-                  <>
-                    <CheckIcon className="h-3.5 w-3.5 text-green-500" />
-                    Kopierat
-                  </>
-                ) : (
-                  <>
-                    <ClipboardDocumentIcon className="h-3.5 w-3.5" />
-                    Kopiera
-                  </>
-                )}
-              </button>
+              <CopyButton text={ingredientsText} />
             </div>
             <div className="mt-3 space-y-4">
               {recipe.ingredients.map((group, groupIndex) => (
@@ -258,3 +222,18 @@ function RecipeDetailPage() {
     </div>
   )
 }
+
+export const Route = createFileRoute('/_authed/recipes/$recipeId')({
+  loader: async ({ params }) => {
+    const [recipe, menuRecipeIds] = await Promise.all([
+      fetchRecipeById({ data: { id: parseInt(params.recipeId, 10) } }),
+      fetchMenuRecipeIds(),
+    ])
+    if (!recipe) {
+      throw new Error('Receptet hittades inte')
+    }
+    return { recipe, menuRecipeIds }
+  },
+  head: ({ loaderData }) => ({ meta: [{ title: `${loaderData.recipe.title} | Tallriken` }] }),
+  component: RecipeDetailPage,
+})

--- a/src/routes/_authed/recipes/edit/$recipeId.tsx
+++ b/src/routes/_authed/recipes/edit/$recipeId.tsx
@@ -6,23 +6,7 @@ import { RecipeForm, type RecipeFormData } from '#/components/recipe-form'
 import { Recipe } from '#/recipes/recipe'
 import { ArrowLeftIcon } from '@heroicons/react/24/outline'
 
-export const Route = createFileRoute('/_authed/recipes/edit/$recipeId')({
-  loader: async ({ params }) => {
-    const recipeId = parseInt(params.recipeId, 10)
-    const [recipe, tags] = await Promise.all([
-      fetchRecipeById({ data: { id: recipeId } }),
-      fetchAllTags(),
-    ])
-    if (!recipe) {
-      throw new Error('Receptet hittades inte')
-    }
-    return { recipe, tags }
-  },
-  head: ({ loaderData }) => ({ meta: [{ title: `Redigera ${loaderData.recipe.title} | Tallriken` }] }),
-  component: EditRecipePage,
-})
-
-function EditRecipePage() {
+const EditRecipePage = () => {
   const { recipe, tags } = Route.useLoaderData()
   const navigate = useNavigate()
   const [error, setError] = useState<string | null>(null)
@@ -73,3 +57,19 @@ function EditRecipePage() {
     </div>
   )
 }
+
+export const Route = createFileRoute('/_authed/recipes/edit/$recipeId')({
+  loader: async ({ params }) => {
+    const recipeId = parseInt(params.recipeId, 10)
+    const [recipe, tags] = await Promise.all([
+      fetchRecipeById({ data: { id: recipeId } }),
+      fetchAllTags(),
+    ])
+    if (!recipe) {
+      throw new Error('Receptet hittades inte')
+    }
+    return { recipe, tags }
+  },
+  head: ({ loaderData }) => ({ meta: [{ title: `Redigera ${loaderData.recipe.title} | Tallriken` }] }),
+  component: EditRecipePage,
+})

--- a/src/routes/_authed/weekly-menu.tsx
+++ b/src/routes/_authed/weekly-menu.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useState } from 'react'
-import { useCopyToClipboard } from '#/hooks/use-copy-to-clipboard'
+import { CopyButton } from '#/components/copy-button'
 import { fetchMenu, removeRecipeFromMenu, clearAllMenu, toggleRecipeComplete, generateAndSaveShoppingList, fetchShoppingList } from '#/menu/server'
 import { Button } from '#/components/ui/button'
 import { ConfirmDialog } from '#/components/ui/confirm-dialog'
@@ -11,25 +11,11 @@ import {
   UsersIcon,
   CalendarIcon,
   CheckCircleIcon,
-  ClipboardDocumentIcon,
-  CheckIcon,
   SparklesIcon,
   ChevronDownIcon,
   ChevronUpIcon,
 } from '@heroicons/react/24/outline'
 import { CheckCircleIcon as CheckCircleIconSolid } from '@heroicons/react/24/solid'
-
-export const Route = createFileRoute('/_authed/weekly-menu')({
-  loader: async () => {
-    const [menu, savedShoppingList] = await Promise.all([
-      fetchMenu(),
-      fetchShoppingList(),
-    ])
-    return { menu, savedShoppingList }
-  },
-  head: () => ({ meta: [{ title: 'Veckans meny | Tallriken' }] }),
-  component: WeeklyMenuPage,
-})
 
 type ShoppingListSectionProps = {
   shoppingList: string | null
@@ -46,15 +32,9 @@ const ShoppingListSection = ({
   onGenerate,
   generating,
 }: ShoppingListSectionProps) => {
-  const { copied, copy: copyToClipboard } = useCopyToClipboard()
-
-  const handleCopy = async () => {
-    if (!shoppingList) return
-    const plainText = shoppingList
-      .replace(/^## /gm, '')
-      .replace(/^- /gm, '  ')
-    await copyToClipboard(plainText)
-  }
+  const plainText = shoppingList
+    ?.replace(/^## /gm, '')
+    .replace(/^- /gm, '  ') ?? ''
 
   return (
     <div className="mt-6 rounded-xl bg-white ring-1 ring-gray-100">
@@ -73,22 +53,7 @@ const ShoppingListSection = ({
         </button>
         <div className="flex items-center gap-2">
           {shoppingList && (
-            <button
-              onClick={handleCopy}
-              className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
-            >
-              {copied ? (
-                <>
-                  <CheckIcon className="h-3.5 w-3.5 text-green-500" />
-                  Kopierat
-                </>
-              ) : (
-                <>
-                  <ClipboardDocumentIcon className="h-3.5 w-3.5" />
-                  Kopiera
-                </>
-              )}
-            </button>
+            <CopyButton text={plainText} />
           )}
           <Button
             size="sm"
@@ -117,7 +82,7 @@ const ShoppingListSection = ({
   )
 }
 
-function WeeklyMenuPage() {
+const WeeklyMenuPage = () => {
   const { menu: initialMenu, savedShoppingList } = Route.useLoaderData()
   const [menu, setMenu] = useState(initialMenu)
   const [showClearConfirm, setShowClearConfirm] = useState(false)
@@ -293,3 +258,15 @@ function WeeklyMenuPage() {
     </div>
   )
 }
+
+export const Route = createFileRoute('/_authed/weekly-menu')({
+  loader: async () => {
+    const [menu, savedShoppingList] = await Promise.all([
+      fetchMenu(),
+      fetchShoppingList(),
+    ])
+    return { menu, savedShoppingList }
+  },
+  head: () => ({ meta: [{ title: 'Veckans meny | Tallriken' }] }),
+  component: WeeklyMenuPage,
+})

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,16 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { requireGuest } from '#/auth/guards'
 
-export const Route = createFileRoute('/login')({
-  validateSearch: (search: Record<string, unknown>) => ({
-    error: search.error as string | undefined,
-  }),
-  head: () => ({ meta: [{ title: 'Logga in | Tallriken' }] }),
-  beforeLoad: requireGuest,
-  component: LoginPage,
-})
-
-function LoginPage() {
+const LoginPage = () => {
   const { error } = Route.useSearch()
 
   return (
@@ -47,3 +38,12 @@ function LoginPage() {
     </main>
   )
 }
+
+export const Route = createFileRoute('/login')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    error: search.error as string | undefined,
+  }),
+  head: () => ({ meta: [{ title: 'Logga in | Tallriken' }] }),
+  beforeLoad: requireGuest,
+  component: LoginPage,
+})

--- a/src/vector/__tests__/recipe-index.test.ts
+++ b/src/vector/__tests__/recipe-index.test.ts
@@ -104,7 +104,6 @@ describe('RecipeIndex', () => {
   describe('backfillAll', () => {
     it('processes all recipes in batches', async () => {
       const db = createTestDb()
-      // Create 3 recipes
       await createTestRecipe(db, { title: 'Recept 1' })
       await createTestRecipe(db, { title: 'Recept 2' })
       await createTestRecipe(db, { title: 'Recept 3' })


### PR DESCRIPTION
## Summary

- Add indexes to `recipe_tags` join table for faster lookups (#112)
- Remove 8 unnecessary comments across the codebase (#114)
- Convert function declarations to arrow functions in all route files (#104)
- Fix `undoCooked` not resetting `lastCookedAt` when `cookCount` reaches 0 (#101)
- Handle JSON-LD `@type` as array in recipe extraction (#103)
- Extract `CopyButton` component to deduplicate copy-to-clipboard UI (#107)

## Test plan

- [x] All 139 tests pass
- [x] No new TypeScript errors introduced
- [x] Drizzle migration generated for indexes