### PR TITLE
Fix chat bubble duplication and weekly menu stale data

### DIFF
--- a/src/chat/chat-panel.tsx
+++ b/src/chat/chat-panel.tsx
@@ -18,16 +18,25 @@ const TOOL_LABELS: Record<string, string> = {
 }
 
 
+type ChatMessageData = {
+  id: string
+  role: string
+  parts: Array<{ type: string; name?: string; content?: string }>
+}
+
 type ChatMessageProps = {
-  message: {
-    id: string
-    role: string
-    parts: Array<{ type: string; name?: string; content?: string }>
-  }
+  message: ChatMessageData
   isLoading: boolean
   copiedId: string | null
   onCopy: (text: string, messageId: string) => void
 }
+
+const isToolOnlyMessage = (message: ChatMessageData): boolean =>
+  message.role === 'assistant' &&
+  message.parts.some((p) => p.type === 'tool-call') &&
+  message.parts
+    .filter((p) => p.type === 'text')
+    .every((p) => !('content' in p) || !p.content?.trim())
 
 const ChatMessage = ({ message, isLoading, copiedId, onCopy }: ChatMessageProps) => {
   const isAssistant = message.role === 'assistant'
@@ -180,20 +189,23 @@ const ChatPanel = () => {
               </ul>
             </div>
           )}
-          {messages.map((message) => (
-            <ChatMessage
-              key={message.id}
-              message={message}
-              isLoading={isLoading}
-              copiedId={copiedId}
-              onCopy={handleCopy}
-            />
-          ))}
-          {isLoading && !messages.some((m) =>
-            m.role === 'assistant' &&
-            m.parts.some((p) => p.type === 'tool-call') &&
-            m.parts.filter((p) => p.type === 'text').every((p) => !('content' in p) || !p.content.trim()),
-          ) && (
+          {messages.map((message, index) => {
+            if (isToolOnlyMessage(message)) {
+              const hasLaterToolOnly = messages.slice(index + 1).some(isToolOnlyMessage)
+              if (hasLaterToolOnly) return null
+            }
+
+            return (
+              <ChatMessage
+                key={message.id}
+                message={message}
+                isLoading={isLoading}
+                copiedId={copiedId}
+                onCopy={handleCopy}
+              />
+            )
+          })}
+          {isLoading && !messages.some(isToolOnlyMessage) && (
             <div className="mb-4">
               <div className="max-w-[85%] rounded-2xl bg-gray-100 px-4 py-2.5 text-sm text-gray-400">
                 Tänker...

--- a/src/routes/_authed/index.tsx
+++ b/src/routes/_authed/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { useState, useEffect } from 'react'
 import { useChatStore } from '#/chat/store'
 import { fetchAllRecipes, findRecipes, fetchFavoriteRecipes, fetchStaleRecipes } from '#/recipes/server'
@@ -86,6 +86,7 @@ const CookingInsights = ({ favorites, stale }: CookingInsightsProps) => {
 
 const HomePage = () => {
   const { recipes: initialRecipes, tags, menuRecipeIds: initialMenuIds, favorites, stale } = Route.useLoaderData()
+  const router = useRouter()
   const setPageContext = useChatStore((s) => s.setPageContext)
   const [recipes, setRecipes] = useState(initialRecipes)
   const [menuRecipeIds, setMenuRecipeIds] = useState<number[]>(initialMenuIds)
@@ -133,6 +134,9 @@ const HomePage = () => {
       setMenuRecipeIds((prev) => [...prev, recipeId])
       await addRecipeToMenu({ data: { recipeId } })
     }
+    router.invalidate({
+      filter: (match) => match.routeId === '/_authed/weekly-menu',
+    })
   }
 
   const toggleTag = (tagId: number) => {


### PR DESCRIPTION
## Summary

- **#116** -- Only render the last tool-only assistant message as a status bubble during loading, instead of one per tool call. Extracts `isToolOnlyMessage` helper to replace duplicated inline logic.
- **#118** -- Add filtered `router.invalidate()` targeting only `/_authed/weekly-menu` after add/remove menu mutations, so the page shows fresh data on navigation without invalidating all routes.

Closes #116, closes #118

## Test plan

- [ ] Open chat, ask something that triggers multiple tool calls (e.g. "vad finns i veckomenyn") -- verify only one status bubble shows
- [ ] Add a recipe to the weekly menu from the home page, navigate to weekly menu -- verify recipes appear without needing a refresh
- [ ] Remove a recipe from the menu, navigate to weekly menu -- verify it's gone