### PR TITLE
Run tag classification and image download concurrently in import pipeline

### DIFF
--- a/src/import/pipeline.ts
+++ b/src/import/pipeline.ts
@@ -69,8 +69,10 @@ const importFromUrl = async (
 
   const jsonLdDraft = extractJsonLdRecipe(html);
   if (jsonLdDraft) {
-    const tagIds = await resolveTagIds(jsonLdDraft, tags, classifyTags);
-    const imageUrl = await resolveImageUrl(html, storeImage);
+    const [tagIds, imageUrl] = await Promise.all([
+      resolveTagIds(jsonLdDraft, tags, classifyTags),
+      resolveImageUrl(html, storeImage),
+    ]);
     return {
       draft: jsonLdDraft,
       tagIds,
@@ -82,8 +84,10 @@ const importFromUrl = async (
 
   const aiDraft = await extractWithAi({ kind: "html", html }, tagNames);
   if (aiDraft) {
-    const tagIds = await resolveTagIds(aiDraft, tags, classifyTags);
-    const imageUrl = await resolveImageUrl(html, storeImage);
+    const [tagIds, imageUrl] = await Promise.all([
+      resolveTagIds(aiDraft, tags, classifyTags),
+      resolveImageUrl(html, storeImage),
+    ]);
     return {
       draft: aiDraft,
       tagIds,


### PR DESCRIPTION
## Summary

- Wrap `resolveTagIds` and `resolveImageUrl` in `Promise.all` in both the JSON-LD and AI extraction branches of the import pipeline
- These two operations are independent (OpenAI API call vs HTTP fetch + R2 upload), so running them in parallel saves wall time during recipe import

Closes #110

## Test plan

- [x] All 139 existing tests pass, including 9 pipeline-specific tests