### PR TITLE
Security hardening: auth, timing-safe comparison, SSRF protection, rate limiting

### DIFF
--- a/drizzle/0006_melted_aqueduct.sql
+++ b/drizzle/0006_melted_aqueduct.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `login_attempts` (
+	`ip` text PRIMARY KEY NOT NULL,
+	`attempts` integer DEFAULT 0 NOT NULL,
+	`last_attempt` integer NOT NULL
+);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,333 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dcea1b9c-969c-42cf-aabc-8afc99e21306",
+  "prevId": "5eb96aeb-e8ad-4918-bcd3-9e57b8a134e2",
+  "tables": {
+    "login_attempts": {
+      "name": "login_attempts",
+      "columns": {
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_attempt": {
+          "name": "last_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipe_tags": {
+      "name": "recipe_tags",
+      "columns": {
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_recipe_tags_recipe_id": {
+          "name": "idx_recipe_tags_recipe_id",
+          "columns": [
+            "recipe_id"
+          ],
+          "isUnique": false
+        },
+        "idx_recipe_tags_tag_id": {
+          "name": "idx_recipe_tags_tag_id",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recipe_tags_recipe_id_recipes_id_fk": {
+          "name": "recipe_tags_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_tags",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_tags_tag_id_tags_id_fk": {
+          "name": "recipe_tags_tag_id_tags_id_fk",
+          "tableFrom": "recipe_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipes": {
+      "name": "recipes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingredients": {
+          "name": "ingredients",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cooking_time_minutes": {
+          "name": "cooking_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "servings": {
+          "name": "servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_cooked_at": {
+          "name": "last_cooked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cook_count": {
+          "name": "cook_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shopping_lists": {
+      "name": "shopping_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weekly_menu_items": {
+      "name": "weekly_menu_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weekly_menu_items_recipe_id_recipes_id_fk": {
+          "name": "weekly_menu_items_recipe_id_recipes_id_fk",
+          "tableFrom": "weekly_menu_items",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1775828061449,
       "tag": "0005_glamorous_lady_ursula",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1775829070982,
+      "tag": "0006_melted_aqueduct",
+      "breakpoints": true
     }
   ]
 }

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -16,7 +16,10 @@ export const validateSessionToken = (token: string, secret: string): boolean => 
   const [payload, signature] = parts
   const expectedSignature = crypto.createHmac('sha256', secret).update(payload).digest('hex')
 
-  if (signature !== expectedSignature) return false
+  const signatureBuffer = Buffer.from(signature, 'hex')
+  const expectedBuffer = Buffer.from(expectedSignature, 'hex')
+  if (signatureBuffer.length !== expectedBuffer.length) return false
+  if (!crypto.timingSafeEqual(signatureBuffer, expectedBuffer)) return false
 
   const expiresAt = parseInt(payload, 10)
   if (isNaN(expiresAt)) return false

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,6 +45,12 @@ export const shoppingListsTable = sqliteTable('shopping_lists', {
     .$defaultFn(() => new Date()),
 })
 
+export const loginAttemptsTable = sqliteTable('login_attempts', {
+  ip: text('ip').primaryKey(),
+  attempts: integer('attempts').notNull().default(0),
+  lastAttempt: integer('last_attempt').notNull(),
+})
+
 export const weeklyMenuItemsTable = sqliteTable('weekly_menu_items', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   recipeId: integer('recipe_id')

--- a/src/images/index.ts
+++ b/src/images/index.ts
@@ -3,6 +3,7 @@ import * as schema from '#/db/schema'
 import type { Database } from '#/db/types'
 import { putToR2, deleteFromR2, keyToUrl, urlToKey } from '#/images/_r2'
 import { generateRecipeImage } from '#/images/_generate'
+import { validatePublicUrl } from '#/utils/url-validation'
 
 const makeKey = {
   forRecipe: (recipeId: number, ext: string) =>
@@ -118,6 +119,8 @@ export const downloadAndStoreImage = async (
   externalUrl: string,
 ): Promise<string | null> => {
   try {
+    validatePublicUrl(externalUrl)
+
     const response = await fetch(externalUrl)
     if (!response.ok) return null
 

--- a/src/import/pipeline.ts
+++ b/src/import/pipeline.ts
@@ -2,6 +2,7 @@ import type { Database } from "#/db/types";
 import { extractImageUrl, extractJsonLdRecipe } from "#/import/extract";
 import type { RecipeDraft } from "#/import/schema";
 import { getAllTags } from "#/tags/crud";
+import { validatePublicUrl } from "#/utils/url-validation";
 
 export type ImportSource =
   | { kind: "url"; url: string }
@@ -236,6 +237,8 @@ const defaultClassifyTags =
   };
 
 const defaultFetchHtml = async (url: string): Promise<string> => {
+  validatePublicUrl(url);
+
   const response = await fetch(url, {
     headers: {
       "User-Agent": "Mozilla/5.0 (compatible; Tallriken/1.0)",

--- a/src/routes/api/auth/login.ts
+++ b/src/routes/api/auth/login.ts
@@ -1,10 +1,83 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { eq } from 'drizzle-orm'
+import { env } from 'cloudflare:workers'
 import { loginWithPassword } from '#/auth/responses'
+import { verifyPassword } from '#/auth/session'
+import { getDb } from '#/db/client'
+import * as schema from '#/db/schema'
+
+const MAX_ATTEMPTS = 5
+const WINDOW_SECONDS = 60
+
+const checkRateLimit = async (ip: string): Promise<boolean> => {
+  const db = getDb()
+  const rows = await db
+    .select()
+    .from(schema.loginAttemptsTable)
+    .where(eq(schema.loginAttemptsTable.ip, ip))
+
+  if (rows.length === 0) return false
+
+  const record = rows[0]
+  const windowStart = Date.now() - WINDOW_SECONDS * 1000
+
+  if (record.lastAttempt < windowStart) return false
+
+  return record.attempts >= MAX_ATTEMPTS
+}
+
+const recordFailedAttempt = async (ip: string): Promise<void> => {
+  const db = getDb()
+  const now = Date.now()
+  const windowStart = now - WINDOW_SECONDS * 1000
+
+  const rows = await db
+    .select()
+    .from(schema.loginAttemptsTable)
+    .where(eq(schema.loginAttemptsTable.ip, ip))
+
+  if (rows.length === 0) {
+    await db.insert(schema.loginAttemptsTable).values({
+      ip,
+      attempts: 1,
+      lastAttempt: now,
+    })
+    return
+  }
+
+  const record = rows[0]
+
+  if (record.lastAttempt < windowStart) {
+    await db
+      .update(schema.loginAttemptsTable)
+      .set({ attempts: 1, lastAttempt: now })
+      .where(eq(schema.loginAttemptsTable.ip, ip))
+  } else {
+    await db
+      .update(schema.loginAttemptsTable)
+      .set({ attempts: record.attempts + 1, lastAttempt: now })
+      .where(eq(schema.loginAttemptsTable.ip, ip))
+  }
+}
+
+const clearAttempts = async (ip: string): Promise<void> => {
+  const db = getDb()
+  await db
+    .delete(schema.loginAttemptsTable)
+    .where(eq(schema.loginAttemptsTable.ip, ip))
+}
 
 export const Route = createFileRoute('/api/auth/login')({
   server: {
     handlers: {
       POST: async ({ request }) => {
+        const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown'
+
+        const isRateLimited = await checkRateLimit(ip)
+        if (isRateLimited) {
+          return new Response('Too Many Requests', { status: 429 })
+        }
+
         const formData = await request.formData()
         const password = formData.get('password')
 
@@ -15,6 +88,15 @@ export const Route = createFileRoute('/api/auth/login')({
           })
         }
 
+        if (!verifyPassword(password, env.APP_PASSWORD)) {
+          await recordFailedAttempt(ip)
+          return new Response(null, {
+            status: 302,
+            headers: { Location: '/login?error=invalid' },
+          })
+        }
+
+        await clearAttempts(ip)
         return loginWithPassword(password)
       },
     },

--- a/src/routes/api/chat.ts
+++ b/src/routes/api/chat.ts
@@ -1,7 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { getCookie } from '@tanstack/react-start/server'
 import { chat, toServerSentEventsResponse, maxIterations } from '@tanstack/ai'
 import { createOpenaiChat } from '@tanstack/ai-openai'
 import { env } from 'cloudflare:workers'
+import { validateSessionToken } from '#/auth/session'
+import { SESSION_COOKIE_NAME } from '#/auth/cookies'
 import { searchRecipesTool, getWeeklyMenuTool, addToWeeklyMenuTool } from '#/chat/tools'
 import { getDb } from '#/db/client'
 import { getAllTags } from '#/tags/crud'
@@ -34,6 +37,11 @@ export const Route = createFileRoute('/api/chat')({
   server: {
     handlers: {
       POST: async ({ request }) => {
+        const sessionToken = getCookie(SESSION_COOKIE_NAME)
+        if (!sessionToken || !validateSessionToken(sessionToken, env.APP_SECRET)) {
+          return new Response('Unauthorized', { status: 401 })
+        }
+
         const { messages, conversationId } = await request.json()
 
         const db = getDb()

--- a/src/routes/api/images/$.ts
+++ b/src/routes/api/images/$.ts
@@ -1,10 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { getCookie } from '@tanstack/react-start/server'
 import { env } from 'cloudflare:workers'
+import { validateSessionToken } from '#/auth/session'
+import { SESSION_COOKIE_NAME } from '#/auth/cookies'
 
 export const Route = createFileRoute('/api/images/$')({
   server: {
     handlers: {
       GET: async ({ params }) => {
+        const sessionToken = getCookie(SESSION_COOKIE_NAME)
+        if (!sessionToken || !validateSessionToken(sessionToken, env.APP_SECRET)) {
+          return new Response('Unauthorized', { status: 401 })
+        }
+
         const key = params._splat
         if (!key) {
           return new Response('Not found', { status: 404 })

--- a/src/utils/url-validation.ts
+++ b/src/utils/url-validation.ts
@@ -1,0 +1,39 @@
+const PRIVATE_IP_PATTERNS = [
+  /^127\./,
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^0\./,
+]
+
+const BLOCKED_HOSTNAMES = ['localhost', '[::1]']
+
+export const validatePublicUrl = (url: string): void => {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(`Invalid URL: ${url}`)
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Blocked URL scheme: ${parsed.protocol}`)
+  }
+
+  const hostname = parsed.hostname
+
+  if (BLOCKED_HOSTNAMES.includes(hostname)) {
+    throw new Error(`Blocked hostname: ${hostname}`)
+  }
+
+  if (hostname === '::1') {
+    throw new Error(`Blocked hostname: ${hostname}`)
+  }
+
+  for (const pattern of PRIVATE_IP_PATTERNS) {
+    if (pattern.test(hostname)) {
+      throw new Error(`Blocked private IP address: ${hostname}`)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add session validation to `/api/chat` POST handler (closes #95)
- Add session validation to `/api/images/$` GET handler (closes #97)
- Replace `!==` with `crypto.timingSafeEqual` for HMAC signature comparison in session validation (closes #98)
- Add `validatePublicUrl` utility that rejects private IPs and non-HTTP(S) schemes, called before fetch in the import pipeline and image download (closes #99)
- Add D1-backed rate limiting to the login endpoint: 5 attempts per IP within 60 seconds, then 429 (closes #100)

## Test plan

- [ ] Verify unauthenticated requests to `/api/chat` return 401
- [ ] Verify unauthenticated requests to `/api/images/*` return 401
- [ ] Verify session validation still works after timing-safe comparison change
- [ ] Verify importing a recipe from a public URL still works
- [ ] Verify importing from localhost/private IPs is rejected
- [ ] Verify login works normally under the rate limit
- [ ] Verify login returns 429 after 5 failed attempts within 60 seconds
- [ ] Run `npm test` -- all 139 tests pass
- [ ] Run migration on D1 to create `login_attempts` table