### PR TITLE
Quick wins: remove stale state, refactor syncRecipeVector, fix search filter

### DIFF
--- a/src/recipes/search.ts
+++ b/src/recipes/search.ts
@@ -51,8 +51,8 @@ const vectorSearch = async (
   const recipes = await getRecipesByIds(db, recipeIds)
 
   const filtered = recipes.filter((r) => {
-    if (maxCookingTimeMinutes && r.cookingTimeMinutes != null) {
-      if (r.cookingTimeMinutes > maxCookingTimeMinutes) return false
+    if (maxCookingTimeMinutes) {
+      if (r.cookingTimeMinutes == null || r.cookingTimeMinutes > maxCookingTimeMinutes) return false
     }
     if (tagIds.length > 0) {
       const recipeTagIds = r.tags.map((t) => t.id)

--- a/src/recipes/server.ts
+++ b/src/recipes/server.ts
@@ -1,6 +1,8 @@
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
+import { inArray } from 'drizzle-orm'
 import { getDb } from '#/db/client'
+import * as schema from '#/db/schema'
 import { createRecipe, getAllRecipes, getRecipeById, updateRecipe, deleteRecipe, getFavoriteRecipes, getStaleRecipes } from '#/recipes/crud'
 import { recipeInputSchema } from '#/recipes/recipe'
 import { createRecipeSearch } from '#/recipes/search'
@@ -8,6 +10,16 @@ import { authMiddleware } from '#/auth/middleware'
 import { getVectorSearch } from '#/vector/client'
 import { createRecipeIndex } from '#/vector/recipe-index'
 import { env } from 'cloudflare:workers'
+import type { Database } from '#/db/types'
+
+const getTagNamesByIds = async (db: Database, tagIds: number[]): Promise<string[]> => {
+  if (tagIds.length === 0) return []
+  const tags = await db
+    .select({ name: schema.tagsTable.name })
+    .from(schema.tagsTable)
+    .where(inArray(schema.tagsTable.id, tagIds))
+  return tags.map((t) => t.name)
+}
 
 export const saveRecipe = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
@@ -15,8 +27,9 @@ export const saveRecipe = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const db = getDb()
     const recipe = await createRecipe(db, data)
+    const tagNames = await getTagNamesByIds(db, data.tagIds)
     const index = createRecipeIndex(db, getVectorSearch(), env.OPENAI_API_KEY)
-    await index.onRecipeSaved(recipe, data.tagIds)
+    await index.onRecipeSaved(recipe, tagNames)
     return recipe
   })
 
@@ -27,8 +40,9 @@ export const editRecipe = createServerFn({ method: 'POST' })
     const db = getDb()
     const { id, ...input } = data
     const recipe = await updateRecipe(db, id, input)
+    const tagNames = await getTagNamesByIds(db, input.tagIds)
     const index = createRecipeIndex(db, getVectorSearch(), env.OPENAI_API_KEY)
-    await index.onRecipeSaved(recipe, input.tagIds)
+    await index.onRecipeSaved(recipe, tagNames)
     return recipe
   })
 

--- a/src/routes/_authed/import.tsx
+++ b/src/routes/_authed/import.tsx
@@ -41,19 +41,6 @@ const ImportPage = () => {
     }
   }
 
-  const handleSave = async () => {
-    if (!previewData) return
-    setSaving(true)
-    setError(null)
-    try {
-      await saveRecipe({ data: { ...Recipe.fromForm(previewData), ...importMeta } })
-      navigate({ to: '/' })
-    } catch {
-      setError('Kunde inte spara receptet. Försök igen.')
-      setSaving(false)
-    }
-  }
-
   if (previewData) {
     return (
       <div className="min-h-screen">
@@ -74,10 +61,17 @@ const ImportPage = () => {
               initialData={previewData}
               initialImageUrl={importMeta.imageUrl}
               tags={tags}
-              onSubmit={(form, formImageUrl) => {
-                setPreviewData(form)
-                setImportMeta((prev) => ({ ...prev, imageUrl: formImageUrl }))
-                handleSave()
+              onSubmit={async (form, formImageUrl) => {
+                setSaving(true)
+                setError(null)
+                try {
+                  const meta = { ...importMeta, imageUrl: formImageUrl }
+                  await saveRecipe({ data: { ...Recipe.fromForm(form), ...meta } })
+                  navigate({ to: '/' })
+                } catch {
+                  setError('Kunde inte spara receptet. Forsok igen.')
+                  setSaving(false)
+                }
               }}
               submitLabel={saving ? 'Sparar...' : 'Spara recept'}
               onCancel={() => setPreviewData(null)}

--- a/src/routes/_authed/index.tsx
+++ b/src/routes/_authed/index.tsx
@@ -94,13 +94,6 @@ const HomePage = () => {
   const [selectedTagIds, setSelectedTagIds] = useState<number[]>([])
 
   useEffect(() => {
-    setRecipes(initialRecipes)
-  }, [initialRecipes])
-
-  useEffect(() => {
-    setMenuRecipeIds(initialMenuIds)
-  }, [initialMenuIds])
-  useEffect(() => {
     setPageContext({ type: 'home' })
     return () => setPageContext({ type: 'other' })
   }, [setPageContext])

--- a/src/vector/__tests__/recipe-index.test.ts
+++ b/src/vector/__tests__/recipe-index.test.ts
@@ -32,7 +32,7 @@ describe('RecipeIndex', () => {
           ingredients: [{ group: null, items: ['pasta', 'ägg'] }],
           cookingTimeMinutes: 25,
         },
-        [],
+        ['Italienskt'],
       )
 
       expect(vectorSearch.upsert).toHaveBeenCalledWith(

--- a/src/vector/__tests__/sync.test.ts
+++ b/src/vector/__tests__/sync.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest'
-import { createTestDb, createTestTag } from '#/test-utils'
 import { syncRecipeVector } from '#/vector/sync'
 import type { VectorSearch } from '#/vector/search'
 
@@ -25,17 +24,20 @@ const createMockVectorSearch = (): VectorSearch & { upsertCalls: unknown[][] } =
 
 describe('syncRecipeVector', () => {
   it('embeds recipe with tag names and upserts vector', async () => {
-    const db = createTestDb()
-    const tag = await createTestTag(db, 'Italienskt')
     const vectorSearch = createMockVectorSearch()
 
-    await syncRecipeVector(vectorSearch, 'test-api-key', db, {
-      id: 1,
-      title: 'Pasta Carbonara',
-      description: 'Klassisk pasta',
-      ingredients: [{ group: null, items: ['pasta', 'ägg'] }],
-      cookingTimeMinutes: 25,
-    }, [tag.id])
+    await syncRecipeVector({
+      vectorSearch,
+      apiKey: 'test-api-key',
+      recipe: {
+        id: 1,
+        title: 'Pasta Carbonara',
+        description: 'Klassisk pasta',
+        ingredients: [{ group: null, items: ['pasta', 'ägg'] }],
+        cookingTimeMinutes: 25,
+      },
+      tagNames: ['Italienskt'],
+    })
 
     expect(vectorSearch.upsert).toHaveBeenCalledWith(
       1,
@@ -45,16 +47,20 @@ describe('syncRecipeVector', () => {
   })
 
   it('handles recipe with no tags', async () => {
-    const db = createTestDb()
     const vectorSearch = createMockVectorSearch()
 
-    await syncRecipeVector(vectorSearch, 'test-api-key', db, {
-      id: 2,
-      title: 'Enkel soppa',
-      description: null,
-      ingredients: [],
-      cookingTimeMinutes: null,
-    }, [])
+    await syncRecipeVector({
+      vectorSearch,
+      apiKey: 'test-api-key',
+      recipe: {
+        id: 2,
+        title: 'Enkel soppa',
+        description: null,
+        ingredients: [],
+        cookingTimeMinutes: null,
+      },
+      tagNames: [],
+    })
 
     expect(vectorSearch.upsert).toHaveBeenCalledWith(
       2,
@@ -63,19 +69,21 @@ describe('syncRecipeVector', () => {
     )
   })
 
-  it('resolves multiple tag names from ids', async () => {
-    const db = createTestDb()
-    const tag1 = await createTestTag(db, 'Snabblagat')
-    const tag2 = await createTestTag(db, 'Barnvänligt')
+  it('passes multiple tag names through to metadata', async () => {
     const vectorSearch = createMockVectorSearch()
 
-    await syncRecipeVector(vectorSearch, 'test-api-key', db, {
-      id: 3,
-      title: 'Pannkakor',
-      description: 'Snabba pannkakor',
-      ingredients: [{ group: null, items: ['mjöl', 'ägg', 'mjölk'] }],
-      cookingTimeMinutes: 15,
-    }, [tag1.id, tag2.id])
+    await syncRecipeVector({
+      vectorSearch,
+      apiKey: 'test-api-key',
+      recipe: {
+        id: 3,
+        title: 'Pannkakor',
+        description: 'Snabba pannkakor',
+        ingredients: [{ group: null, items: ['mjöl', 'ägg', 'mjölk'] }],
+        cookingTimeMinutes: 15,
+      },
+      tagNames: ['Snabblagat', 'Barnvänligt'],
+    })
 
     const metadata = vectorSearch.upsertCalls[0][2] as Record<string, unknown>
     expect(metadata.tagNames).toHaveLength(2)

--- a/src/vector/recipe-index.ts
+++ b/src/vector/recipe-index.ts
@@ -6,7 +6,7 @@ import { syncRecipeVector, type SyncRecipe } from '#/vector/sync'
 import { getAllRecipes, getRecipesByIds } from '#/recipes/crud'
 
 export type RecipeIndex = {
-  onRecipeSaved: (recipe: SyncRecipe, tagIds: number[]) => Promise<void>
+  onRecipeSaved: (recipe: SyncRecipe, tagNames: string[]) => Promise<void>
   onRecipeDeleted: (recipeId: number) => Promise<void>
   onTagRenamed: (tagId: number) => Promise<void>
   backfillAll: () => Promise<{ total: number }>
@@ -25,8 +25,8 @@ export const createRecipeIndex = (
   vectorSearch: VectorSearch,
   apiKey: string,
 ): RecipeIndex => ({
-  onRecipeSaved: async (recipe, tagIds) => {
-    await syncRecipeVector(vectorSearch, apiKey, db, recipe, tagIds)
+  onRecipeSaved: async (recipe, tagNames) => {
+    await syncRecipeVector({ vectorSearch, apiKey, recipe, tagNames })
   },
 
   onRecipeDeleted: async (recipeId) => {
@@ -46,7 +46,12 @@ export const createRecipeIndex = (
 
     await Promise.all(
       recipes.map((recipe) =>
-        syncRecipeVector(vectorSearch, apiKey, db, recipe, recipe.tags.map((t) => t.id)),
+        syncRecipeVector({
+          vectorSearch,
+          apiKey,
+          recipe,
+          tagNames: recipe.tags.map((t) => t.name),
+        }),
       ),
     )
   },
@@ -57,7 +62,12 @@ export const createRecipeIndex = (
     for (const batch of chunk(recipes, 10)) {
       await Promise.all(
         batch.map((recipe) =>
-          syncRecipeVector(vectorSearch, apiKey, db, recipe, recipe.tags.map((t) => t.id)),
+          syncRecipeVector({
+            vectorSearch,
+            apiKey,
+            recipe,
+            tagNames: recipe.tags.map((t) => t.name),
+          }),
         ),
       )
     }

--- a/src/vector/sync.ts
+++ b/src/vector/sync.ts
@@ -1,6 +1,3 @@
-import { inArray } from 'drizzle-orm'
-import * as schema from '#/db/schema'
-import type { Database } from '#/db/types'
 import type { VectorSearch } from '#/vector/search'
 import { buildEmbeddingText, embed } from '#/vector/embed'
 
@@ -12,20 +9,15 @@ export type SyncRecipe = {
   cookingTimeMinutes: number | null
 }
 
-export const syncRecipeVector = async (
-  vectorSearch: VectorSearch,
-  apiKey: string,
-  db: Database,
-  recipe: SyncRecipe,
-  tagIds: number[],
-): Promise<void> => {
-  const tagNames = tagIds.length > 0
-    ? (await db
-        .select({ name: schema.tagsTable.name })
-        .from(schema.tagsTable)
-        .where(inArray(schema.tagsTable.id, tagIds))
-      ).map((t) => t.name)
-    : []
+type SyncRecipeVectorOptions = {
+  vectorSearch: VectorSearch
+  apiKey: string
+  recipe: SyncRecipe
+  tagNames: string[]
+}
+
+export const syncRecipeVector = async (options: SyncRecipeVectorOptions): Promise<void> => {
+  const { vectorSearch, apiKey, recipe, tagNames } = options
 
   const text = buildEmbeddingText({
     title: recipe.title,


### PR DESCRIPTION
## Summary

- Remove unnecessary useEffect state syncing on home page -- useState initializers are sufficient since TanStack Router remounts with fresh loader data
- Refactor syncRecipeVector to accept an options object with tagNames instead of 5 positional args with tagIds, removing the redundant DB lookup from the function
- Fix stale state bug in import preview save by passing form data directly to save logic instead of closing over stale previewData
- Fix vector search to exclude recipes with null cookingTimeMinutes when maxCookingTimeMinutes filter is set

Closes #96, closes #102, closes #109, closes #111, closes #113

## Test plan

- [x] All 139 existing tests pass
- [ ] Verify home page still loads and search works after removing useEffect syncing
- [ ] Verify import preview save works with edited form data
- [ ] Verify vector search correctly filters out recipes without cooking time