### PR TITLE
Extract PageShell layout component to reduce route boilerplate

### DIFF
--- a/src/components/page-shell.tsx
+++ b/src/components/page-shell.tsx
@@ -1,0 +1,53 @@
+import { Link } from '@tanstack/react-router'
+import { ArrowLeftIcon } from '@heroicons/react/24/outline'
+
+type BackLink = {
+  to: string
+  params?: Record<string, string>
+  onBack?: never
+}
+
+type BackButton = {
+  to?: never
+  params?: never
+  onBack: () => void
+}
+
+type PageShellProps = (BackLink | BackButton) & {
+  label?: string
+  children: React.ReactNode
+}
+
+export const PageShell = ({
+  to,
+  params,
+  onBack,
+  label = 'Tillbaka',
+  children,
+}: PageShellProps) => (
+  <div className="min-h-screen">
+    <nav className="border-b border-gray-100 bg-white">
+      <div className="mx-auto flex max-w-4xl items-center px-4 py-3">
+        {onBack ? (
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800"
+          >
+            <ArrowLeftIcon className="h-4 w-4" />
+            {label}
+          </button>
+        ) : (
+          <Link
+            to={to}
+            params={params}
+            className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800"
+          >
+            <ArrowLeftIcon className="h-4 w-4" />
+            {label}
+          </Link>
+        )}
+      </div>
+    </nav>
+    <main className="mx-auto max-w-4xl px-4 py-8">{children}</main>
+  </div>
+)

--- a/src/routes/_authed/admin/tags.tsx
+++ b/src/routes/_authed/admin/tags.tsx
@@ -1,11 +1,11 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { useState } from 'react'
 import { fetchAllTags, addTag, updateTagName, removeTag } from '#/tags/server'
+import { PageShell } from '#/components/page-shell'
 import { Button } from '#/components/ui/button'
 import { Input } from '#/components/ui/input'
 import { ConfirmDialog } from '#/components/ui/confirm-dialog'
 import {
-  ArrowLeftIcon,
   TagIcon,
   PencilIcon,
   TrashIcon,
@@ -66,17 +66,7 @@ const TagsAdminPage = () => {
   }
 
   return (
-    <div className="min-h-screen">
-      <nav className="border-b border-gray-100 bg-white">
-        <div className="mx-auto flex max-w-4xl items-center px-4 py-3">
-          <Link to="/" className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800">
-            <ArrowLeftIcon className="h-4 w-4" />
-            Tillbaka
-          </Link>
-        </div>
-      </nav>
-
-      <main className="mx-auto max-w-4xl px-4 py-8">
+    <PageShell to="/">
         <h1 className="text-2xl font-extrabold tracking-tight text-gray-900">Hantera taggar</h1>
 
         {error && <div className="mt-4 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>}
@@ -145,8 +135,7 @@ const TagsAdminPage = () => {
           description={`Är du säker på att du vill ta bort "${deleteTarget?.name}"?`}
           onConfirm={handleDelete}
         />
-      </main>
-    </div>
+    </PageShell>
   )
 }
 

--- a/src/routes/_authed/admin/vectors.tsx
+++ b/src/routes/_authed/admin/vectors.tsx
@@ -1,12 +1,10 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { useState } from 'react'
+import { PageShell } from '#/components/page-shell'
 import { Button } from '#/components/ui/button'
 import { ConfirmDialog } from '#/components/ui/confirm-dialog'
 import { triggerBackfill } from '#/vector/server'
-import {
-  ArrowLeftIcon,
-  ArrowPathIcon,
-} from '@heroicons/react/24/outline'
+import { ArrowPathIcon } from '@heroicons/react/24/outline'
 
 const VectorsAdminPage = () => {
   const [showConfirm, setShowConfirm] = useState(false)
@@ -27,17 +25,7 @@ const VectorsAdminPage = () => {
   }
 
   return (
-    <div className="min-h-screen">
-      <nav className="border-b border-gray-100 bg-white">
-        <div className="mx-auto flex max-w-4xl items-center px-4 py-3">
-          <Link to="/" className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800">
-            <ArrowLeftIcon className="h-4 w-4" />
-            Tillbaka
-          </Link>
-        </div>
-      </nav>
-
-      <main className="mx-auto max-w-4xl px-4 py-8">
+    <PageShell to="/">
         <h1 className="text-2xl font-extrabold tracking-tight text-gray-900">Vektorsök</h1>
         <p className="mt-2 text-sm text-gray-500">
           Hantera vektordatabasen som driver semantisk sökning. Kör backfill efter att du synkat receptdata till prod.
@@ -67,8 +55,6 @@ const VectorsAdminPage = () => {
             </div>
           )}
         </div>
-      </main>
-
       <ConfirmDialog
         open={showConfirm}
         onOpenChange={setShowConfirm}
@@ -78,7 +64,7 @@ const VectorsAdminPage = () => {
         confirmVariant="primary"
         onConfirm={handleBackfill}
       />
-    </div>
+    </PageShell>
   )
 }
 

--- a/src/routes/_authed/import.tsx
+++ b/src/routes/_authed/import.tsx
@@ -1,14 +1,14 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { fetchAllTags } from '#/tags/server'
 import { saveRecipe } from '#/recipes/server'
 import { extractRecipeFromUrl, extractRecipeFromPhotos } from '#/import/server'
 import { Recipe } from '#/recipes/recipe'
+import { PageShell } from '#/components/page-shell'
 import { Button } from '#/components/ui/button'
 import { Input } from '#/components/ui/input'
 import { RecipeForm, TabButton, type RecipeFormData } from '#/components/recipe-form'
 import { fileToBase64 } from '#/utils/file'
-import { ArrowLeftIcon } from '@heroicons/react/24/outline'
 
 type ImportTab = 'url' | 'photo' | 'manual'
 
@@ -43,16 +43,7 @@ const ImportPage = () => {
 
   if (previewData) {
     return (
-      <div className="min-h-screen">
-        <nav className="border-b border-gray-100 bg-white">
-          <div className="mx-auto flex max-w-4xl items-center px-4 py-3">
-            <button onClick={() => setPreviewData(null)} className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800">
-              <ArrowLeftIcon className="h-4 w-4" />
-              Tillbaka
-            </button>
-          </div>
-        </nav>
-        <main className="mx-auto max-w-4xl px-4 py-8">
+      <PageShell onBack={() => setPreviewData(null)}>
           <h1 className="text-2xl font-extrabold tracking-tight text-gray-900">Granska recept</h1>
           <p className="mt-1 text-sm text-gray-500">Granska och redigera innan du sparar.</p>
           {error && <div className="mt-4 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>}
@@ -77,23 +68,12 @@ const ImportPage = () => {
               onCancel={() => setPreviewData(null)}
             />
           </div>
-        </main>
-      </div>
+      </PageShell>
     )
   }
 
   return (
-    <div className="min-h-screen">
-      <nav className="border-b border-gray-100 bg-white">
-        <div className="mx-auto flex max-w-4xl items-center px-4 py-3">
-          <Link to="/" className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800">
-            <ArrowLeftIcon className="h-4 w-4" />
-            Tillbaka
-          </Link>
-        </div>
-      </nav>
-
-      <main className="mx-auto max-w-4xl px-4 py-8">
+    <PageShell to="/">
         <h1 className="text-2xl font-extrabold tracking-tight text-gray-900">Lägg till recept</h1>
 
         <div className="mt-5 flex gap-4 border-b border-gray-200">
@@ -158,8 +138,7 @@ const ImportPage = () => {
             />
           </div>
         )}
-      </main>
-    </div>
+    </PageShell>
   )
 }
 

--- a/src/routes/_authed/recipes/$recipeId.tsx
+++ b/src/routes/_authed/recipes/$recipeId.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useState, useEffect } from 'react'
 import { useChatStore } from '#/chat/store'
 import { CopyButton } from '#/components/copy-button'
+import { PageShell } from '#/components/page-shell'
 import { fetchRecipeById, removeRecipe } from '#/recipes/server'
 import { generateAndSaveImage, uploadImageForRecipe } from '#/images/server'
 import { fetchMenuRecipeIds, addRecipeToMenu, removeRecipeFromMenu } from '#/menu/server'
@@ -15,7 +16,6 @@ import {
 } from '#/components/ui/dropdown-menu'
 import { ConfirmDialog } from '#/components/ui/confirm-dialog'
 import {
-  ArrowLeftIcon,
   ClockIcon,
   UsersIcon,
   ArrowTopRightOnSquareIcon,
@@ -71,17 +71,7 @@ const RecipeDetailPage = () => {
   }
 
   return (
-    <div className="min-h-screen">
-      <nav className="border-b border-gray-100 bg-white">
-        <div className="mx-auto flex max-w-4xl items-center px-4 py-3">
-          <Link to="/" className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800">
-            <ArrowLeftIcon className="h-4 w-4" />
-            Tillbaka
-          </Link>
-        </div>
-      </nav>
-
-      <main className="mx-auto max-w-4xl px-4 py-8">
+    <PageShell to="/">
         <div className="overflow-hidden rounded-xl bg-white ring-1 ring-gray-100">
           <ImagePicker
             imageUrl={currentImageUrl ?? undefined}
@@ -210,8 +200,6 @@ const RecipeDetailPage = () => {
           )}
           </div>
         </div>
-      </main>
-
       <ConfirmDialog
         open={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}
@@ -219,7 +207,7 @@ const RecipeDetailPage = () => {
         description={`Är du säker på att du vill ta bort "${recipe.title}"?`}
         onConfirm={handleDelete}
       />
-    </div>
+    </PageShell>
   )
 }
 

--- a/src/routes/_authed/recipes/edit/$recipeId.tsx
+++ b/src/routes/_authed/recipes/edit/$recipeId.tsx
@@ -1,10 +1,10 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { fetchRecipeById, editRecipe } from '#/recipes/server'
 import { fetchAllTags } from '#/tags/server'
+import { PageShell } from '#/components/page-shell'
 import { RecipeForm, type RecipeFormData } from '#/components/recipe-form'
 import { Recipe } from '#/recipes/recipe'
-import { ArrowLeftIcon } from '@heroicons/react/24/outline'
 
 const EditRecipePage = () => {
   const { recipe, tags } = Route.useLoaderData()
@@ -26,21 +26,7 @@ const EditRecipePage = () => {
   }
 
   return (
-    <div className="min-h-screen">
-      <nav className="border-b border-gray-100 bg-white">
-        <div className="mx-auto flex max-w-4xl items-center px-4 py-3">
-          <Link
-            to="/recipes/$recipeId"
-            params={{ recipeId: String(recipe.id) }}
-            className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800"
-          >
-            <ArrowLeftIcon className="h-4 w-4" />
-            Tillbaka
-          </Link>
-        </div>
-      </nav>
-
-      <main className="mx-auto max-w-4xl px-4 py-8">
+    <PageShell to="/recipes/$recipeId" params={{ recipeId: String(recipe.id) }}>
         <h1 className="text-2xl font-extrabold tracking-tight text-gray-900">Redigera recept</h1>
         {error && <div className="mt-4 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>}
         <div className="mt-6 rounded-xl bg-white p-5 ring-1 ring-gray-100">
@@ -53,8 +39,7 @@ const EditRecipePage = () => {
             onCancel={() => navigate({ to: '/recipes/$recipeId', params: { recipeId: String(recipe.id) } })}
           />
         </div>
-      </main>
-    </div>
+    </PageShell>
   )
 }
 

--- a/src/routes/_authed/weekly-menu.tsx
+++ b/src/routes/_authed/weekly-menu.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useState } from 'react'
 import { CopyButton } from '#/components/copy-button'
+import { PageShell } from '#/components/page-shell'
 import { fetchMenu, removeRecipeFromMenu, clearAllMenu, toggleRecipeComplete, generateAndSaveShoppingList, fetchShoppingList } from '#/menu/server'
 import { Button } from '#/components/ui/button'
 import { ConfirmDialog } from '#/components/ui/confirm-dialog'
 import {
-  ArrowLeftIcon,
   TrashIcon,
   ClockIcon,
   UsersIcon,
@@ -127,17 +127,7 @@ const WeeklyMenuPage = () => {
   }
 
   return (
-    <div className="min-h-screen">
-      <nav className="border-b border-gray-100 bg-white">
-        <div className="mx-auto flex max-w-4xl items-center px-4 py-3">
-          <Link to="/" className="flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-800">
-            <ArrowLeftIcon className="h-4 w-4" />
-            Tillbaka
-          </Link>
-        </div>
-      </nav>
-
-      <main className="mx-auto max-w-4xl px-4 py-8">
+    <PageShell to="/">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-extrabold tracking-tight text-gray-900">Veckans meny</h1>
           {menu.length > 0 && (
@@ -254,8 +244,7 @@ const WeeklyMenuPage = () => {
           confirmLabel="Rensa"
           onConfirm={handleClear}
         />
-      </main>
-    </div>
+    </PageShell>
   )
 }
 


### PR DESCRIPTION
## Summary

Closes #106

- Extracts the repeated `div > nav > main` page layout into a reusable `PageShell` component in `src/components/page-shell.tsx`
- Supports both `Link`-based navigation (`to` prop) and callback-based navigation (`onBack` prop) via a discriminated union type
- Replaces duplicated layout markup across 6 route files (7 usages total, including the dual-shell in import.tsx)
- Removes unused `ArrowLeftIcon` and `Link` imports from updated routes

## Files changed

- **New:** `src/components/page-shell.tsx`
- `src/routes/_authed/weekly-menu.tsx`
- `src/routes/_authed/recipes/$recipeId.tsx`
- `src/routes/_authed/recipes/edit/$recipeId.tsx`
- `src/routes/_authed/import.tsx`
- `src/routes/_authed/admin/tags.tsx`
- `src/routes/_authed/admin/vectors.tsx`

## Test plan

- [x] All 139 tests pass
- [x] No new type errors (tsc --noEmit)
- [ ] Verify back navigation works on all affected pages
- [ ] Verify import.tsx preview back button still resets state correctly
- [ ] Verify edit page back link navigates to recipe detail (not home)