### PR TITLE
Extract getRecipeIndex factory and deduplicate image upload

### DIFF
--- a/src/images/index.ts
+++ b/src/images/index.ts
@@ -59,21 +59,30 @@ const getRecipeOrThrow = async (db: Database, recipeId: number) => {
   return recipes[0]
 }
 
+const storeRecipeImage = async (
+  db: Database,
+  recipeId: number,
+  data: ArrayBuffer,
+  mimeType: string,
+  ext: string,
+): Promise<{ imageUrl: string }> => {
+  const recipe = await getRecipeOrThrow(db, recipeId)
+  await deleteOldImage(recipe.imageUrl)
+  const key = makeKey.forRecipe(recipeId, ext)
+  await putToR2(key, data, mimeType)
+  const imageUrl = keyToUrl(key)
+  await updateRecipeImageUrl(db, recipeId, imageUrl)
+  return { imageUrl }
+}
+
 export const generateImageForRecipe = async (
   db: Database,
   recipeId: number,
   apiKey: string,
 ): Promise<{ imageUrl: string }> => {
   const recipe = await getRecipeOrThrow(db, recipeId)
-  await deleteOldImage(recipe.imageUrl)
-
   const imageData = await generateRecipeImage(recipe.title, recipe.description, apiKey)
-  const key = makeKey.forRecipe(recipeId, 'png')
-  await putToR2(key, imageData, 'image/png')
-
-  const imageUrl = keyToUrl(key)
-  await updateRecipeImageUrl(db, recipeId, imageUrl)
-  return { imageUrl }
+  return storeRecipeImage(db, recipeId, imageData, 'image/png', 'png')
 }
 
 export const uploadImageForRecipe = async (
@@ -82,16 +91,8 @@ export const uploadImageForRecipe = async (
   base64: string,
   mimeType: string,
 ): Promise<{ imageUrl: string }> => {
-  const recipe = await getRecipeOrThrow(db, recipeId)
-  await deleteOldImage(recipe.imageUrl)
-
   const data = decodeBase64(base64)
-  const key = makeKey.forRecipe(recipeId, extFromMime(mimeType))
-  await putToR2(key, data, mimeType)
-
-  const imageUrl = keyToUrl(key)
-  await updateRecipeImageUrl(db, recipeId, imageUrl)
-  return { imageUrl }
+  return storeRecipeImage(db, recipeId, data, mimeType, extFromMime(mimeType))
 }
 
 export const generateImagePreview = async (

--- a/src/recipes/server.ts
+++ b/src/recipes/server.ts
@@ -7,9 +7,7 @@ import { createRecipe, getAllRecipes, getRecipeById, updateRecipe, deleteRecipe,
 import { recipeInputSchema } from '#/recipes/recipe'
 import { createRecipeSearch } from '#/recipes/search'
 import { authMiddleware } from '#/auth/middleware'
-import { getVectorSearch } from '#/vector/client'
-import { createRecipeIndex } from '#/vector/recipe-index'
-import { env } from 'cloudflare:workers'
+import { getVectorSearch, getRecipeIndex } from '#/vector/client'
 import type { Database } from '#/db/types'
 
 const getTagNamesByIds = async (db: Database, tagIds: number[]): Promise<string[]> => {
@@ -28,7 +26,7 @@ export const saveRecipe = createServerFn({ method: 'POST' })
     const db = getDb()
     const recipe = await createRecipe(db, data)
     const tagNames = await getTagNamesByIds(db, data.tagIds)
-    const index = createRecipeIndex(db, getVectorSearch(), env.OPENAI_API_KEY)
+    const index = getRecipeIndex()
     await index.onRecipeSaved(recipe, tagNames)
     return recipe
   })
@@ -41,7 +39,7 @@ export const editRecipe = createServerFn({ method: 'POST' })
     const { id, ...input } = data
     const recipe = await updateRecipe(db, id, input)
     const tagNames = await getTagNamesByIds(db, input.tagIds)
-    const index = createRecipeIndex(db, getVectorSearch(), env.OPENAI_API_KEY)
+    const index = getRecipeIndex()
     await index.onRecipeSaved(recipe, tagNames)
     return recipe
   })
@@ -52,7 +50,7 @@ export const removeRecipe = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const db = getDb()
     await deleteRecipe(db, data.id)
-    const index = createRecipeIndex(db, getVectorSearch(), env.OPENAI_API_KEY)
+    const index = getRecipeIndex()
     await index.onRecipeDeleted(data.id)
   })
 

--- a/src/tags/server.ts
+++ b/src/tags/server.ts
@@ -1,11 +1,9 @@
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
-import { env } from 'cloudflare:workers'
 import { getDb } from '#/db/client'
 import { createTag, getAllTags, renameTag, deleteTag } from '#/tags/crud'
 import { authMiddleware } from '#/auth/middleware'
-import { getVectorSearch } from '#/vector/client'
-import { createRecipeIndex } from '#/vector/recipe-index'
+import { getRecipeIndex } from '#/vector/client'
 
 export const fetchAllTags = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
@@ -29,7 +27,7 @@ export const updateTagName = createServerFn({ method: 'POST' })
     const db = getDb()
     const tag = await renameTag(db, data.id, data.name)
 
-    const index = createRecipeIndex(db, getVectorSearch(), env.OPENAI_API_KEY)
+    const index = getRecipeIndex()
     await index.onTagRenamed(data.id)
 
     return tag

--- a/src/vector/client.ts
+++ b/src/vector/client.ts
@@ -1,6 +1,11 @@
 import { env } from 'cloudflare:workers'
 import { createVectorSearch } from '#/vector/search'
+import { createRecipeIndex } from '#/vector/recipe-index'
+import { getDb } from '#/db/client'
 
 export const getVectorSearch = () => {
   return createVectorSearch(env.VECTORIZE, env.OPENAI_API_KEY)
 }
+
+export const getRecipeIndex = () =>
+  createRecipeIndex(getDb(), getVectorSearch(), env.OPENAI_API_KEY)

--- a/src/vector/server.ts
+++ b/src/vector/server.ts
@@ -1,14 +1,10 @@
 import { createServerFn } from '@tanstack/react-start'
-import { env } from 'cloudflare:workers'
-import { getDb } from '#/db/client'
-import { getVectorSearch } from '#/vector/client'
-import { createRecipeIndex } from '#/vector/recipe-index'
+import { getRecipeIndex } from '#/vector/client'
 import { authMiddleware } from '#/auth/middleware'
 
 export const triggerBackfill = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .handler(async () => {
-    const db = getDb()
-    const index = createRecipeIndex(db, getVectorSearch(), env.OPENAI_API_KEY)
+    const index = getRecipeIndex()
     return index.backfillAll()
   })


### PR DESCRIPTION
## Summary
- Extract `getRecipeIndex()` zero-arg factory in `src/vector/client.ts`, replacing 5 identical `createRecipeIndex(db, getVectorSearch(), env.OPENAI_API_KEY)` call sites
- Extract `storeRecipeImage()` helper in `src/images/index.ts`, deduplicating shared logic between `generateImageForRecipe` and `uploadImageForRecipe`

Closes #105, closes #108

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm test` passes (139 tests, including image tests)