### PR TITLE
Lower vector search similarity threshold

### DIFF
--- a/src/vector/search.ts
+++ b/src/vector/search.ts
@@ -1,6 +1,6 @@
 import { embed } from '#/vector/embed'
 
-const MIN_SIMILARITY_SCORE = 0.3
+const MIN_SIMILARITY_SCORE = 0.2
 
 type FindSimilarOptions = {
   query: string


### PR DESCRIPTION
## Summary
- Lower `MIN_SIMILARITY_SCORE` from 0.3 to 0.2 in vector search to improve recall for ingredient-based matches
- Fixes a bug where recipes are not found when the search term only appears in ingredients (e.g., searching for "pasta" not finding "Majscarbonara" which has "400g pasta" as an ingredient)

With `text-embedding-3-small`, a short query like "pasta" against a document where "pasta" is one ingredient among many can score below 0.3. Lowering to 0.2 is a common threshold for this model and improves recall without returning irrelevant results.

Also closes #91 -- the recipe search unification described in that issue has already been completed in previous PRs. Both the server API and chat tools use the shared `createRecipeSearch` module.

Closes #91

## Test plan
- [x] All 139 tests pass
- [ ] Verify "pasta" query finds Majscarbonara in production after deploy