### PR TITLE
Fix chat search: fall back to DB when vector returns empty

### DIFF
--- a/src/recipes/__tests__/search.test.ts
+++ b/src/recipes/__tests__/search.test.ts
@@ -175,6 +175,20 @@ describe('recipe search with vector search', () => {
     expect(results[0].title).toBe('Snabbsallad')
   })
 
+  it('falls back to DB search when vector search returns empty', async () => {
+    const db = createTestDb()
+    await createTestRecipe(db, { title: 'Pasta Carbonara' })
+
+    const findSimilar: FindSimilar = vi.fn().mockResolvedValue([])
+
+    const search = createRecipeSearch(db, findSimilar)
+    const results = await search.search({ query: 'pasta' })
+
+    expect(findSimilar).toHaveBeenCalled()
+    expect(results).toHaveLength(1)
+    expect(results[0].title).toBe('Pasta Carbonara')
+  })
+
   it('falls back to DB search when vector search throws', async () => {
     const db = createTestDb()
     await createTestRecipe(db, { title: 'Pasta Carbonara' })

--- a/src/recipes/search.ts
+++ b/src/recipes/search.ts
@@ -26,10 +26,10 @@ export const createRecipeSearch = (db: Database, findSimilar?: FindSimilar): Rec
 
     if (findSimilar && hasQuery) {
       try {
-        return await vectorSearch(db, findSimilar, query, tagIds, params.maxCookingTimeMinutes)
+        const results = await vectorSearch(db, findSimilar, query, tagIds, params.maxCookingTimeMinutes)
+        if (results.length > 0) return results
       } catch (error) {
         console.error('[search] vector search failed, falling back to DB search:', error)
-        return fallbackSearch(db, query, tagIds, params.maxCookingTimeMinutes)
       }
     }
 


### PR DESCRIPTION
## Summary
Fix a bug where the AI chat assistant couldn't find recipes and would default to reading the weekly menu instead.

**Root cause:** When vector search succeeded but returned 0 results (all scores below the similarity threshold), the search returned an empty array immediately with no fallback to DB text search. The DB fallback only triggered when vector search threw an error.

This meant queries like "pastarätter" would fail to find "Majscarbonara" (which has "400g pasta" in ingredients) because:
1. Vector similarity score was below threshold -> empty vector results
2. Empty results returned directly, skipping DB search
3. DB LIKE search (which would match "pasta" in ingredients) never ran
4. AI got empty results -> gave up on search_recipes -> tried get_weekly_menu

**Fix:** If vector search returns empty results, fall through to DB text search instead of returning immediately. Both error AND empty-result cases now trigger the fallback.

## Test plan
- [x] New test: "falls back to DB search when vector search returns empty"
- [x] All 140 tests pass
- [ ] Verify in prod: ask chat "har vi några pastarätter" and confirm it finds recipes