### PR TITLE
Improve chat search resilience and upgrade to gpt-4.1-mini

### DIFF
--- a/src/chat/tools.ts
+++ b/src/chat/tools.ts
@@ -53,6 +53,10 @@ const searchRecipesDef = toolDefinition({
     'Sök efter recept i användarens receptsamling med semantisk sökning. Skriv alltid en beskrivande sökfras, t.ex. "snabba barnvänliga rätter" eller "vegetarisk pasta". Returnerar recept rankade efter relevans.',
   inputSchema: z.object({
     query: z.string().describe('Beskrivande sökfras på naturligt språk (t.ex. "enkel vegetarisk middag", "barnvänligt under 30 min")'),
+    tags: z
+      .array(z.string())
+      .optional()
+      .describe('Filtrera på taggnamn (t.ex. ["Pasta", "Barnvänligt"]). Använd EXAKT de taggnamn som finns i samlingen.'),
     maxCookingTimeMinutes: z
       .number()
       .optional()
@@ -62,13 +66,13 @@ const searchRecipesDef = toolDefinition({
 })
 
 export const searchRecipesTool = searchRecipesDef.server(
-  async ({ query, maxCookingTimeMinutes }) => {
+  async ({ query, tags, maxCookingTimeMinutes }) => {
     const db = getDb()
     const vectorSearch = getVectorSearch()
     const search = createRecipeSearch(db, (q) =>
-      vectorSearch.findSimilar({ query: q, topK: 15 }),
+      vectorSearch.findSimilar({ query: q, topK: 20 }),
     )
-    const results = await search.search({ query, maxCookingTimeMinutes })
+    const results = await search.search({ query, tags, maxCookingTimeMinutes })
     return results.map(formatResult)
   },
 )

--- a/src/routes/api/chat.ts
+++ b/src/routes/api/chat.ts
@@ -14,10 +14,12 @@ const SYSTEM_PROMPT = `Du är Tallrikens receptassistent. Du hjälper användare
 VIKTIGT om sökning:
 - Verktyget search_recipes använder semantisk sökning. Skriv alltid en beskrivande sökfras, t.ex. "snabba barnvänliga rätter" eller "enkel vegetarisk pasta".
 - ALLTID sök med search_recipes INNAN du svarar på frågor om recept. Svara ALDRIG att recept inte finns utan att först ha sökt.
+- Om sökningen ger tomt resultat, GE INTE UPP. Prova igen med en kortare eller annorlunda formulering. Exempel: om "krämig kycklingpasta" ger tomt, prova "kyckling" eller "pasta". Gör minst 2-3 sökningar innan du säger att inget hittades.
 - Inkludera kategori, önskemål och begränsningar direkt i sökfrasen istället för att använda separata filter.
 - Du kan bedöma kosttyp genom att titta på ingredienserna.
 - Använd maxCookingTimeMinutes-parametern om användaren anger en specifik tidsgräns.
 - Använd cookCount och lastCookedAt för att svara på frågor om matlagningshistorik.
+- När du presenterar resultat, visa ALLA relevanta träffar, inte bara det bästa resultatet.
 
 VIKTIGT om veckomenyn:
 - Verktyget get_weekly_menu hämtar aktuella planerade recept.
@@ -55,12 +57,12 @@ export const Route = createFileRoute('/api/chat')({
           : ''
 
         const stream = chat({
-          adapter: createOpenaiChat('gpt-4o-mini', env.OPENAI_API_KEY),
+          adapter: createOpenaiChat('gpt-4.1-mini', env.OPENAI_API_KEY),
           systemPrompts: [SYSTEM_PROMPT + tagSection],
           messages,
           conversationId,
           tools: [searchRecipesTool, getWeeklyMenuTool, addToWeeklyMenuTool],
-          agentLoopStrategy: maxIterations(5),
+          agentLoopStrategy: maxIterations(12),
         })
 
         return toServerSentEventsResponse(stream)


### PR DESCRIPTION
## Summary
- Upgrade chat model from gpt-4o-mini to gpt-4.1-mini for better tool calling and instruction following
- Add retry instructions to system prompt so the AI makes 2-3 search attempts with different phrasings before giving up
- Add instruction to present all matching results, not just the top one
- Add tags parameter to search_recipes tool (was missing despite system prompt mentioning tags)
- Increase topK from 15 to 20 for more vector search candidates
- Increase agent loop iterations from 5 to 12 for more room to retry searches

gpt-4.1-mini costs ~2.5x more than gpt-4o-mini ($0.40 vs $0.15/M input tokens) but has significantly better tool calling quality per OpenAI benchmarks. Negligible cost difference for a personal app.

## Test plan
- [x] All 140 tests pass
- [ ] Ask chat "har vi några pastarätter" and verify it finds recipes
- [ ] Ask chat "snabba barnvänliga rätter" and verify it uses tags
- [ ] Ask something vague and verify the AI retries with different queries