### PR TITLE
Fix search null filter, add debounce, clean up vector metadata

### DIFF
--- a/src/recipes/crud.ts
+++ b/src/recipes/crud.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNotNull, like, lte, or } from 'drizzle-orm'
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, like, lte, or } from 'drizzle-orm'
 import * as schema from '#/db/schema'
 import type { Database } from '#/db/types'
 import type { RecipeInput } from '#/recipes/recipe'
@@ -104,7 +104,10 @@ export const searchRecipes = async (db: Database, filters: SearchFilters) => {
 
   if (filters.maxCookingTimeMinutes) {
     conditions.push(
-      lte(schema.recipesTable.cookingTimeMinutes, filters.maxCookingTimeMinutes),
+      or(
+        lte(schema.recipesTable.cookingTimeMinutes, filters.maxCookingTimeMinutes),
+        isNull(schema.recipesTable.cookingTimeMinutes),
+      ),
     )
   }
 

--- a/src/recipes/search.ts
+++ b/src/recipes/search.ts
@@ -52,7 +52,7 @@ const vectorSearch = async (
 
   const filtered = recipes.filter((r) => {
     if (maxCookingTimeMinutes) {
-      if (r.cookingTimeMinutes == null || r.cookingTimeMinutes > maxCookingTimeMinutes) return false
+      if (r.cookingTimeMinutes != null && r.cookingTimeMinutes > maxCookingTimeMinutes) return false
     }
     if (tagIds.length > 0) {
       const recipeTagIds = r.tags.map((t) => t.id)

--- a/src/routes/_authed/index.tsx
+++ b/src/routes/_authed/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useChatStore } from '#/chat/store'
 import { fetchAllRecipes, findRecipes, fetchFavoriteRecipes, fetchStaleRecipes } from '#/recipes/server'
 import { fetchAllTags } from '#/tags/server'
@@ -98,7 +98,9 @@ const HomePage = () => {
     return () => setPageContext({ type: 'other' })
   }, [setPageContext])
 
-  const handleSearch = async (query: string, tagIds: number[]) => {
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
+
+  const handleSearch = useCallback(async (query: string, tagIds: number[]) => {
     if (!query.trim() && tagIds.length === 0) {
       setRecipes(initialRecipes)
     } else {
@@ -110,11 +112,14 @@ const HomePage = () => {
       })
       setRecipes(results)
     }
-  }
+  }, [initialRecipes])
 
   const handleQueryChange = (value: string) => {
     setSearchQuery(value)
-    handleSearch(value, selectedTagIds)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      handleSearch(value, selectedTagIds)
+    }, 250)
   }
 
   const handleToggleMenu = async (e: React.MouseEvent, recipeId: number) => {

--- a/src/vector/__tests__/recipe-index.test.ts
+++ b/src/vector/__tests__/recipe-index.test.ts
@@ -38,7 +38,6 @@ describe('RecipeIndex', () => {
       expect(vectorSearch.upsert).toHaveBeenCalledWith(
         1,
         expect.any(Array),
-        expect.objectContaining({ cookingTimeMinutes: 25 }),
       )
     })
   })

--- a/src/vector/__tests__/sync.test.ts
+++ b/src/vector/__tests__/sync.test.ts
@@ -10,17 +10,11 @@ vi.mock('#/vector/embed', async (importOriginal) => {
   }
 })
 
-const createMockVectorSearch = (): VectorSearch & { upsertCalls: unknown[][] } => {
-  const upsertCalls: unknown[][] = []
-  return {
-    upsertCalls,
-    findSimilar: vi.fn().mockResolvedValue([]),
-    upsert: vi.fn(async (...args: unknown[]) => {
-      upsertCalls.push(args)
-    }),
-    remove: vi.fn(),
-  }
-}
+const createMockVectorSearch = (): VectorSearch => ({
+  findSimilar: vi.fn().mockResolvedValue([]),
+  upsert: vi.fn(),
+  remove: vi.fn(),
+})
 
 describe('syncRecipeVector', () => {
   it('embeds recipe with tag names and upserts vector', async () => {
@@ -42,7 +36,6 @@ describe('syncRecipeVector', () => {
     expect(vectorSearch.upsert).toHaveBeenCalledWith(
       1,
       expect.any(Array),
-      { tagNames: ['Italienskt'], cookingTimeMinutes: 25 },
     )
   })
 
@@ -65,11 +58,10 @@ describe('syncRecipeVector', () => {
     expect(vectorSearch.upsert).toHaveBeenCalledWith(
       2,
       expect.any(Array),
-      { tagNames: [], cookingTimeMinutes: 0 },
     )
   })
 
-  it('passes multiple tag names through to metadata', async () => {
+  it('upserts vector for recipe with multiple tags', async () => {
     const vectorSearch = createMockVectorSearch()
 
     await syncRecipeVector({
@@ -85,9 +77,9 @@ describe('syncRecipeVector', () => {
       tagNames: ['Snabblagat', 'Barnvänligt'],
     })
 
-    const metadata = vectorSearch.upsertCalls[0][2] as Record<string, unknown>
-    expect(metadata.tagNames).toHaveLength(2)
-    expect(metadata.tagNames).toContain('Snabblagat')
-    expect(metadata.tagNames).toContain('Barnvänligt')
+    expect(vectorSearch.upsert).toHaveBeenCalledWith(
+      3,
+      expect.any(Array),
+    )
   })
 })

--- a/src/vector/search.ts
+++ b/src/vector/search.ts
@@ -5,7 +5,6 @@ const MIN_SIMILARITY_SCORE = 0.2
 type FindSimilarOptions = {
   query: string
   topK?: number
-  filter?: VectorizeVectorMetadataFilter
 }
 
 export type FindSimilarResult = {
@@ -19,13 +18,11 @@ export const createVectorSearch = (vectorize: VectorizeIndex, apiKey: string) =>
   findSimilar: async ({
     query,
     topK = 10,
-    filter,
   }: FindSimilarOptions): Promise<FindSimilarResult[]> => {
     const queryVector = await embed(query, apiKey)
 
     const results = await vectorize.query(queryVector, {
       topK,
-      filter,
       returnMetadata: 'none',
     })
 
@@ -40,13 +37,11 @@ export const createVectorSearch = (vectorize: VectorizeIndex, apiKey: string) =>
   upsert: async (
     recipeId: number,
     vector: number[],
-    metadata: Record<string, string | number | string[]>,
   ): Promise<void> => {
     await vectorize.upsert([
       {
         id: String(recipeId),
         values: vector,
-        metadata,
       },
     ])
   },

--- a/src/vector/sync.ts
+++ b/src/vector/sync.ts
@@ -29,8 +29,5 @@ export const syncRecipeVector = async (options: SyncRecipeVectorOptions): Promis
 
   const vector = await embed(text, apiKey)
 
-  await vectorSearch.upsert(recipe.id, vector, {
-    tagNames,
-    cookingTimeMinutes: recipe.cookingTimeMinutes ?? 0,
-  })
+  await vectorSearch.upsert(recipe.id, vector)
 }


### PR DESCRIPTION
## Summary

- **Include recipes with null cooking time in filtered search** -- `searchRecipes` now uses `OR(lte, isNull)` instead of just `lte`, so recipes without a recorded cooking time show up when filtering by max time. Same fix applied to the vector search post-filter. Closes #136.
- **Add 250ms debounce to search input** -- `handleQueryChange` on the home page no longer fires a server function per keystroke. Tag toggles still search immediately. Closes #138.
- **Remove unused vector metadata** -- `syncRecipeVector` no longer stores `tagNames` and `cookingTimeMinutes` in Vectorize metadata (it was never read back). Removed the unused `filter` parameter from `findSimilar`. Closes #139.

## Test plan

- [ ] All 140 tests pass
- [ ] Search with max cooking time filter returns recipes that have no cooking time set
- [ ] Typing in search input only triggers search after a brief pause
- [ ] Vector backfill still works from admin page (upsert without metadata)