### PR TITLE
Add drag-and-drop reordering for cooking steps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@cloudflare/vite-plugin": "^1.26.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@fontsource/inter": "^5.2.8",
         "@fontsource/nunito": "^5.2.7",
         "@heroicons/react": "^2.2.0",
@@ -548,6 +550,60 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@cloudflare/vite-plugin": "^1.26.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/nunito": "^5.2.7",
     "@heroicons/react": "^2.2.0",

--- a/src/components/recipe-form.tsx
+++ b/src/components/recipe-form.tsx
@@ -5,6 +5,7 @@ import { Input } from '#/components/ui/input'
 import { Textarea } from '#/components/ui/textarea'
 import { ImagePicker } from '#/components/image-picker'
 import { PlusIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { SortableStepsList } from '#/components/sortable-steps-list'
 import { generateImageFromDetails, uploadRecipeImage } from '#/images/server'
 import { Recipe, recipeFormSchema } from '#/recipes/recipe'
 
@@ -425,35 +426,7 @@ const RecipeForm = ({ initialData, initialImageUrl, tags, onSubmit, submitLabel,
                 <FieldError field={stepsField} />
               )}
               <div className="mt-2 space-y-2">
-                {stepsField.state.value.map((_, index) => (
-                  <div key={index} className="flex gap-2">
-                    <div className="flex min-w-0 flex-1 items-center gap-2">
-                      <span className="shrink-0 text-sm font-bold tabular-nums text-plum-600">
-                        {index + 1}.
-                      </span>
-                      <form.Field
-                        name={`steps[${index}]`}
-                        children={(field) => (
-                          <Input
-                            value={field.state.value}
-                            onChange={(e) => field.handleChange(e.target.value)}
-                            onBlur={field.handleBlur}
-                            placeholder={`Steg ${index + 1}`}
-                          />
-                        )}
-                      />
-                    </div>
-                    {stepsField.state.value.length > 1 && (
-                      <button
-                        type="button"
-                        onClick={() => stepsField.removeValue(index)}
-                        className="shrink-0 rounded-lg p-2 text-gray-400 transition hover:bg-red-50 hover:text-red-500"
-                      >
-                        <XMarkIcon className="h-4 w-4" />
-                      </button>
-                    )}
-                  </div>
-                ))}
+                <SortableStepsList stepsField={stepsField} form={form} />
                 <button
                   type="button"
                   onClick={() => stepsField.pushValue('')}

--- a/src/components/sortable-step-item.tsx
+++ b/src/components/sortable-step-item.tsx
@@ -1,0 +1,100 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Input } from '#/components/ui/input'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+
+import type { AnyFieldApi } from '@tanstack/react-form'
+
+type SortableStepItemProps = {
+  id: string
+  index: number
+  form: { Field: React.ComponentType<any> }
+  stepsField: AnyFieldApi
+  canDelete: boolean
+}
+
+const DragHandle = () => (
+  <button
+    type="button"
+    className="touch-none shrink-0 cursor-grab rounded p-1 text-gray-400 transition hover:text-plum-600 active:cursor-grabbing"
+    aria-label="Dra för att ändra ordning"
+  >
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <circle cx="5" cy="3" r="1.5" />
+      <circle cx="11" cy="3" r="1.5" />
+      <circle cx="5" cy="8" r="1.5" />
+      <circle cx="11" cy="8" r="1.5" />
+      <circle cx="5" cy="13" r="1.5" />
+      <circle cx="11" cy="13" r="1.5" />
+    </svg>
+  </button>
+)
+
+const SortableStepItem = ({
+  id,
+  index,
+  form,
+  stepsField,
+  canDelete,
+}: SortableStepItemProps) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-2 ${isDragging ? 'z-10 opacity-50' : ''}`}
+    >
+      <div {...attributes} {...listeners}>
+        <DragHandle />
+      </div>
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="shrink-0 text-sm font-bold tabular-nums text-plum-600">
+          {index + 1}.
+        </span>
+        <form.Field
+          name={`steps[${index}]`}
+          children={(field: AnyFieldApi) => (
+            <Input
+              value={field.state.value}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                field.handleChange(e.target.value)
+              }
+              onBlur={field.handleBlur}
+              placeholder={`Steg ${index + 1}`}
+            />
+          )}
+        />
+      </div>
+      {canDelete && (
+        <button
+          type="button"
+          onClick={() => stepsField.removeValue(index)}
+          className="shrink-0 rounded-lg p-2 text-gray-400 transition hover:bg-red-50 hover:text-red-500"
+        >
+          <XMarkIcon className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+export { SortableStepItem }

--- a/src/components/sortable-steps-list.tsx
+++ b/src/components/sortable-steps-list.tsx
@@ -1,0 +1,121 @@
+import { useState, useRef } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { SortableStepItem } from '#/components/sortable-step-item'
+import { Input } from '#/components/ui/input'
+
+import type { DragStartEvent, DragEndEvent } from '@dnd-kit/core'
+import type { AnyFieldApi } from '@tanstack/react-form'
+
+type SortableStepsListProps = {
+  stepsField: AnyFieldApi
+  form: { Field: React.ComponentType<any> }
+}
+
+let nextStableId = 0
+const generateId = () => `step-${nextStableId++}`
+
+const SortableStepsList = ({ stepsField, form }: SortableStepsListProps) => {
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const stableIdsRef = useRef<string[] | null>(null)
+  const steps = stepsField.state.value as string[]
+
+  if (stableIdsRef.current === null) {
+    stableIdsRef.current = steps.map(() => generateId())
+  }
+
+  while (stableIdsRef.current.length < steps.length) {
+    stableIdsRef.current.push(generateId())
+  }
+  if (stableIdsRef.current.length > steps.length) {
+    stableIdsRef.current = stableIdsRef.current.slice(0, steps.length)
+  }
+
+  const ids = stableIdsRef.current
+
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: 8 },
+  })
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: { delay: 200, tolerance: 5 },
+  })
+  const sensors = useSensors(pointerSensor, touchSensor)
+
+  const activeIndex = activeId ? ids.indexOf(activeId) : null
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(String(event.active.id))
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveId(null)
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = ids.indexOf(String(active.id))
+    const newIndex = ids.indexOf(String(over.id))
+
+    stableIdsRef.current = arrayMove(ids, oldIndex, newIndex)
+    stepsField.setValue(arrayMove(steps, oldIndex, newIndex))
+  }
+
+  const handleDragCancel = () => {
+    setActiveId(null)
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+        <div className="space-y-2">
+          {steps.map((_, index) => (
+            <SortableStepItem
+              key={ids[index]}
+              id={ids[index]}
+              index={index}
+              form={form}
+              stepsField={stepsField}
+              canDelete={steps.length > 1}
+            />
+          ))}
+        </div>
+      </SortableContext>
+      <DragOverlay>
+        {activeIndex !== null && (
+          <div className="flex gap-2 rounded-xl border border-plum-200 bg-white p-2 shadow-lg">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <span className="shrink-0 text-sm font-bold tabular-nums text-plum-600">
+                {activeIndex + 1}.
+              </span>
+              <Input
+                value={steps[activeIndex]}
+                readOnly
+                tabIndex={-1}
+              />
+            </div>
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
+  )
+}
+
+export { SortableStepsList }


### PR DESCRIPTION
Closes #141

## Summary
- Add drag-and-drop reordering to cooking steps in the recipe form using @dnd-kit
- Each step gets a six-dot drag handle for mouse and touch interaction
- Extracted `SortableStepsList` and `SortableStepItem` components to keep drag logic isolated from the form
- Works across all flows (create, edit, import) since they share RecipeForm

## Test plan
- [ ] Create a recipe with multiple steps, drag to reorder, verify step numbers update
- [ ] Edit an existing recipe, reorder steps, save, verify order persists
- [ ] Test on mobile/touch - long press handle to start drag
- [ ] Add and delete steps after reordering, verify no stale state
- [ ] Import a recipe from URL, reorder steps in the review form