### PR TITLE
Extract vector sync logic into createSyncedMutations

### DIFF
--- a/src/recipes/server.ts
+++ b/src/recipes/server.ts
@@ -1,57 +1,33 @@
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
-import { inArray } from 'drizzle-orm'
 import { getDb } from '#/db/client'
-import * as schema from '#/db/schema'
-import { createRecipe, getAllRecipes, getRecipeById, updateRecipe, deleteRecipe, getFavoriteRecipes, getStaleRecipes } from '#/recipes/crud'
+import { getAllRecipes, getRecipeById, getFavoriteRecipes, getStaleRecipes } from '#/recipes/crud'
 import { recipeInputSchema } from '#/recipes/recipe'
 import { createRecipeSearch } from '#/recipes/search'
 import { authMiddleware } from '#/auth/middleware'
 import { getVectorSearch, getRecipeIndex } from '#/vector/client'
-import type { Database } from '#/db/types'
+import { createSyncedMutations } from '#/vector/with-vector-sync'
 
-const getTagNamesByIds = async (db: Database, tagIds: number[]): Promise<string[]> => {
-  if (tagIds.length === 0) return []
-  const tags = await db
-    .select({ name: schema.tagsTable.name })
-    .from(schema.tagsTable)
-    .where(inArray(schema.tagsTable.id, tagIds))
-  return tags.map((t) => t.name)
-}
+const getMutations = () => createSyncedMutations(getDb(), getRecipeIndex())
 
 export const saveRecipe = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(recipeInputSchema)
-  .handler(async ({ data }) => {
-    const db = getDb()
-    const recipe = await createRecipe(db, data)
-    const tagNames = await getTagNamesByIds(db, data.tagIds)
-    const index = getRecipeIndex()
-    await index.onRecipeSaved(recipe, tagNames)
-    return recipe
-  })
+  .handler(async ({ data }) => getMutations().createRecipe(data))
 
 export const editRecipe = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(recipeInputSchema.extend({ id: z.number() }))
   .handler(async ({ data }) => {
-    const db = getDb()
     const { id, ...input } = data
-    const recipe = await updateRecipe(db, id, input)
-    const tagNames = await getTagNamesByIds(db, input.tagIds)
-    const index = getRecipeIndex()
-    await index.onRecipeSaved(recipe, tagNames)
-    return recipe
+    return getMutations().updateRecipe(id, input)
   })
 
 export const removeRecipe = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(z.object({ id: z.number() }))
   .handler(async ({ data }) => {
-    const db = getDb()
-    await deleteRecipe(db, data.id)
-    const index = getRecipeIndex()
-    await index.onRecipeDeleted(data.id)
+    await getMutations().deleteRecipe(data.id)
   })
 
 export const fetchAllRecipes = createServerFn({ method: 'GET' })

--- a/src/tags/crud.ts
+++ b/src/tags/crud.ts
@@ -1,6 +1,15 @@
-import { asc, eq } from 'drizzle-orm'
+import { asc, eq, inArray } from 'drizzle-orm'
 import * as schema from '#/db/schema'
 import type { Database } from '#/db/types'
+
+export const getTagNamesByIds = async (db: Database, tagIds: number[]): Promise<string[]> => {
+  if (tagIds.length === 0) return []
+  const tags = await db
+    .select({ name: schema.tagsTable.name })
+    .from(schema.tagsTable)
+    .where(inArray(schema.tagsTable.id, tagIds))
+  return tags.map((t) => t.name)
+}
 
 export const createTag = async (db: Database, name: string) => {
   const result = await db

--- a/src/tags/server.ts
+++ b/src/tags/server.ts
@@ -1,9 +1,12 @@
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
 import { getDb } from '#/db/client'
-import { createTag, getAllTags, renameTag, deleteTag } from '#/tags/crud'
+import { createTag, getAllTags, deleteTag } from '#/tags/crud'
 import { authMiddleware } from '#/auth/middleware'
 import { getRecipeIndex } from '#/vector/client'
+import { createSyncedMutations } from '#/vector/with-vector-sync'
+
+const getMutations = () => createSyncedMutations(getDb(), getRecipeIndex())
 
 export const fetchAllTags = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
@@ -23,15 +26,7 @@ export const addTag = createServerFn({ method: 'POST' })
 export const updateTagName = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(z.object({ id: z.number(), name: z.string().min(1) }))
-  .handler(async ({ data }) => {
-    const db = getDb()
-    const tag = await renameTag(db, data.id, data.name)
-
-    const index = getRecipeIndex()
-    await index.onTagRenamed(data.id)
-
-    return tag
-  })
+  .handler(async ({ data }) => getMutations().renameTag(data.id, data.name))
 
 export const removeTag = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])

--- a/src/vector/__tests__/with-vector-sync.test.ts
+++ b/src/vector/__tests__/with-vector-sync.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { createTestDb, createTestTag, createTestRecipe } from '#/test-utils'
+import { createSyncedMutations } from '#/vector/with-vector-sync'
+import type { RecipeIndex } from '#/vector/recipe-index'
+import * as schema from '#/db/schema'
+
+const createMockIndex = (): RecipeIndex => ({
+  onRecipeSaved: vi.fn().mockResolvedValue(undefined),
+  onRecipeDeleted: vi.fn().mockResolvedValue(undefined),
+  onTagRenamed: vi.fn().mockResolvedValue(undefined),
+  backfillAll: vi.fn().mockResolvedValue({ total: 0 }),
+})
+
+describe('createSyncedMutations', () => {
+  describe('createRecipe', () => {
+    it('persists the recipe and syncs vector with resolved tag names', async () => {
+      const db = createTestDb()
+      const italianTag = await createTestTag(db, 'Italienskt')
+      const quickTag = await createTestTag(db, 'Snabblagat')
+      const index = createMockIndex()
+      const mutations = createSyncedMutations(db, index)
+
+      const recipe = await mutations.createRecipe({
+        title: 'Pasta Carbonara',
+        ingredients: [{ group: null, items: ['pasta', 'ägg'] }],
+        tagIds: [italianTag.id, quickTag.id],
+      })
+
+      const persisted = await db
+        .select()
+        .from(schema.recipesTable)
+        .where(eq(schema.recipesTable.id, recipe.id))
+      expect(persisted).toHaveLength(1)
+      expect(persisted[0].title).toBe('Pasta Carbonara')
+
+      expect(index.onRecipeSaved).toHaveBeenCalledTimes(1)
+      expect(index.onRecipeSaved).toHaveBeenCalledWith(
+        expect.objectContaining({ id: recipe.id, title: 'Pasta Carbonara' }),
+        expect.arrayContaining(['Italienskt', 'Snabblagat']),
+      )
+    })
+
+    it('syncs with empty tag names when recipe has no tags', async () => {
+      const db = createTestDb()
+      const index = createMockIndex()
+      const mutations = createSyncedMutations(db, index)
+
+      const recipe = await mutations.createRecipe({
+        title: 'Taggfri',
+        ingredients: [{ group: null, items: ['vatten'] }],
+        tagIds: [],
+      })
+
+      expect(index.onRecipeSaved).toHaveBeenCalledWith(
+        expect.objectContaining({ id: recipe.id }),
+        [],
+      )
+    })
+  })
+
+  describe('updateRecipe', () => {
+    it('persists changes and syncs vector with updated tag names', async () => {
+      const db = createTestDb()
+      const oldTag = await createTestTag(db, 'Gammal')
+      const newTag = await createTestTag(db, 'Ny')
+      const existing = await createTestRecipe(db, {
+        title: 'Gammalt namn',
+        tagIds: [oldTag.id],
+      })
+
+      const index = createMockIndex()
+      const mutations = createSyncedMutations(db, index)
+
+      const updated = await mutations.updateRecipe(existing.id, {
+        title: 'Nytt namn',
+        ingredients: [{ group: null, items: ['ingrediens'] }],
+        tagIds: [newTag.id],
+      })
+
+      const persisted = await db
+        .select()
+        .from(schema.recipesTable)
+        .where(eq(schema.recipesTable.id, existing.id))
+      expect(persisted[0].title).toBe('Nytt namn')
+
+      expect(index.onRecipeSaved).toHaveBeenCalledTimes(1)
+      expect(index.onRecipeSaved).toHaveBeenCalledWith(
+        expect.objectContaining({ id: updated.id, title: 'Nytt namn' }),
+        ['Ny'],
+      )
+    })
+  })
+
+  describe('deleteRecipe', () => {
+    it('removes the recipe and notifies the vector index', async () => {
+      const db = createTestDb()
+      const recipe = await createTestRecipe(db, { title: 'Ska raderas' })
+      const index = createMockIndex()
+      const mutations = createSyncedMutations(db, index)
+
+      await mutations.deleteRecipe(recipe.id)
+
+      const remaining = await db
+        .select()
+        .from(schema.recipesTable)
+        .where(eq(schema.recipesTable.id, recipe.id))
+      expect(remaining).toHaveLength(0)
+
+      expect(index.onRecipeDeleted).toHaveBeenCalledWith(recipe.id)
+    })
+  })
+
+  describe('renameTag', () => {
+    it('updates the tag name and notifies the vector index', async () => {
+      const db = createTestDb()
+      const tag = await createTestTag(db, 'Gammal')
+      const index = createMockIndex()
+      const mutations = createSyncedMutations(db, index)
+
+      const renamed = await mutations.renameTag(tag.id, 'Ny')
+
+      expect(renamed.name).toBe('Ny')
+      const persisted = await db
+        .select()
+        .from(schema.tagsTable)
+        .where(eq(schema.tagsTable.id, tag.id))
+      expect(persisted[0].name).toBe('Ny')
+
+      expect(index.onTagRenamed).toHaveBeenCalledWith(tag.id)
+    })
+  })
+})

--- a/src/vector/with-vector-sync.ts
+++ b/src/vector/with-vector-sync.ts
@@ -1,0 +1,32 @@
+import { createRecipe, deleteRecipe, updateRecipe } from '#/recipes/crud'
+import { getTagNamesByIds, renameTag } from '#/tags/crud'
+import type { Database } from '#/db/types'
+import type { RecipeInput } from '#/recipes/recipe'
+import type { RecipeIndex } from '#/vector/recipe-index'
+
+export const createSyncedMutations = (db: Database, index: RecipeIndex) => ({
+  createRecipe: async (input: RecipeInput) => {
+    const recipe = await createRecipe(db, input)
+    const tagNames = await getTagNamesByIds(db, input.tagIds)
+    await index.onRecipeSaved(recipe, tagNames)
+    return recipe
+  },
+
+  updateRecipe: async (id: number, input: RecipeInput) => {
+    const recipe = await updateRecipe(db, id, input)
+    const tagNames = await getTagNamesByIds(db, input.tagIds)
+    await index.onRecipeSaved(recipe, tagNames)
+    return recipe
+  },
+
+  deleteRecipe: async (id: number) => {
+    await deleteRecipe(db, id)
+    await index.onRecipeDeleted(id)
+  },
+
+  renameTag: async (id: number, newName: string) => {
+    const tag = await renameTag(db, id, newName)
+    await index.onTagRenamed(id)
+    return tag
+  },
+})


### PR DESCRIPTION
## Summary

- Introduced `createSyncedMutations` in `src/vector/with-vector-sync.ts` -- a factory that wraps each DB mutation with the corresponding vector index call, eliminating repeated boilerplate in server functions
- Simplified `src/recipes/server.ts` and `src/tags/server.ts` by replacing inline sync logic with `getMutations()` calls
- Moved `getTagNamesByIds` from `src/recipes/server.ts` into `src/tags/crud.ts` where it belongs
- Added unit tests covering all four mutations: `createRecipe`, `updateRecipe`, `deleteRecipe`, and `renameTag`

## Testing

- `npm test` -- all tests pass, including the new `with-vector-sync.test.ts` suite
- Create a recipe, verify it appears in search results (vector sync fired)
- Edit a recipe's tags, verify search results reflect the updated tags
- Delete a recipe, verify it no longer appears in search results
- Rename a tag, verify recipes with that tag still surface under the new name