### PR TITLE
Refactor import pipeline module interface

### DIFF
--- a/src/import/__tests__/pipeline.test.ts
+++ b/src/import/__tests__/pipeline.test.ts
@@ -1,5 +1,5 @@
-import type { ImportDeps } from "#/import/pipeline";
-import { importRecipe } from "#/import/pipeline";
+import type { ImportDeps, ImportTestOverrides } from "#/import/pipeline";
+import { importFromPhotos, importFromUrl } from "#/import/pipeline";
 import type { RecipeDraft } from "#/import/schema";
 import { createTestDb, createTestTag } from "#/test-utils";
 import { describe, expect, it } from "vitest";
@@ -26,6 +26,12 @@ const JSON_LD_HTML = `
 const createTestDeps = (overrides: Partial<ImportDeps> = {}): ImportDeps => ({
   db: createTestDb(),
   openaiApiKey: "unused",
+  ...overrides,
+});
+
+const urlStubs = (
+  overrides: ImportTestOverrides = {},
+): ImportTestOverrides => ({
   fetchHtml: async () => "",
   extractWithAi: async () => null,
   classifyTags: async () => [],
@@ -33,13 +39,14 @@ const createTestDeps = (overrides: Partial<ImportDeps> = {}): ImportDeps => ({
   ...overrides,
 });
 
-describe("importRecipe", () => {
+describe("importFromUrl", () => {
   it("extracts recipe from JSON-LD without calling AI", async () => {
     let aiWasCalled = false;
 
-    const result = await importRecipe(
-      { kind: "url", url: "https://example.com/recipe" },
-      createTestDeps({
+    const result = await importFromUrl(
+      "https://example.com/recipe",
+      createTestDeps(),
+      urlStubs({
         fetchHtml: async () => JSON_LD_HTML,
         extractWithAi: async () => {
           aiWasCalled = true;
@@ -70,9 +77,10 @@ describe("importRecipe", () => {
       suggestedTagNames: null,
     };
 
-    const result = await importRecipe(
-      { kind: "url", url: "https://example.com/recipe" },
-      createTestDeps({
+    const result = await importFromUrl(
+      "https://example.com/recipe",
+      createTestDeps(),
+      urlStubs({
         fetchHtml: async () => "<html><body>Some recipe text</body></html>",
         extractWithAi: async (input) => {
           expect(input.kind).toBe("html");
@@ -83,38 +91,6 @@ describe("importRecipe", () => {
 
     expect(result.draft.title).toBe("AI-extraherat recept");
     expect(result.extraction).toBe("ai");
-  });
-
-  it("extracts recipe from photos via OCR", async () => {
-    const ocrDraft: RecipeDraft = {
-      title: "Fotograferat recept",
-      description: null,
-      ingredients: [{ group: null, items: ["2 dl grädde"] }],
-      steps: ["Vispa grädden"],
-      cookingTimeMinutes: null,
-      servings: null,
-      suggestedTagNames: null,
-    };
-
-    const images = [{ base64: "abc123", mimeType: "image/jpeg" }];
-
-    const result = await importRecipe(
-      { kind: "photos", images },
-      createTestDeps({
-        extractWithAi: async (input) => {
-          expect(input.kind).toBe("images");
-          if (input.kind === "images") {
-            expect(input.images).toEqual(images);
-          }
-          return ocrDraft;
-        },
-      }),
-    );
-
-    expect(result.draft.title).toBe("Fotograferat recept");
-    expect(result.extraction).toBe("ocr");
-    expect(result.imageUrl).toBeNull();
-    expect(result.sourceUrl).toBeUndefined();
   });
 
   it("resolves tag IDs from AI-suggested tag names (case-insensitive)", async () => {
@@ -133,10 +109,10 @@ describe("importRecipe", () => {
       suggestedTagNames: ["dessert", "VEGETARISKT"],
     };
 
-    const result = await importRecipe(
-      { kind: "url", url: "https://example.com/mousse" },
-      createTestDeps({
-        db,
+    const result = await importFromUrl(
+      "https://example.com/mousse",
+      createTestDeps({ db }),
+      urlStubs({
         fetchHtml: async () => "<html><body>No JSON-LD here</body></html>",
         extractWithAi: async () => draft,
       }),
@@ -155,15 +131,19 @@ describe("importRecipe", () => {
 
     let classifyCallCount = 0;
 
-    const result = await importRecipe(
-      { kind: "url", url: "https://example.com/salmon" },
-      createTestDeps({
-        db,
+    const result = await importFromUrl(
+      "https://example.com/salmon",
+      createTestDeps({ db }),
+      urlStubs({
         fetchHtml: async () => JSON_LD_HTML,
         classifyTags: async (recipe, tagNames) => {
           classifyCallCount++;
           expect(recipe.title).toBe("Pannkakor");
-          expect(recipe.ingredients).toEqual(["3 dl mjöl", "6 dl mjölk", "3 ägg"]);
+          expect(recipe.ingredients).toEqual([
+            "3 dl mjöl",
+            "6 dl mjölk",
+            "3 ägg",
+          ]);
           expect(tagNames).toEqual(expect.arrayContaining(["Fisk", "Dessert"]));
           return ["Fisk"];
         },
@@ -194,9 +174,10 @@ describe("importRecipe", () => {
 
     let storedUrl: string | null = null;
 
-    const result = await importRecipe(
-      { kind: "url", url: "https://example.com/pasta" },
-      createTestDeps({
+    const result = await importFromUrl(
+      "https://example.com/pasta",
+      createTestDeps(),
+      urlStubs({
         fetchHtml: async () => htmlWithImage,
         storeImage: async (url) => {
           storedUrl = url;
@@ -211,9 +192,10 @@ describe("importRecipe", () => {
 
   it("throws when both JSON-LD and AI extraction fail", async () => {
     await expect(
-      importRecipe(
-        { kind: "url", url: "https://example.com/bad" },
-        createTestDeps({
+      importFromUrl(
+        "https://example.com/bad",
+        createTestDeps(),
+        urlStubs({
           fetchHtml: async () => "<html><body>Not a recipe</body></html>",
           extractWithAi: async () => null,
         }),
@@ -223,27 +205,58 @@ describe("importRecipe", () => {
     );
   });
 
-  it("throws when OCR extraction returns null", async () => {
-    await expect(
-      importRecipe(
-        { kind: "photos", images: [{ base64: "abc", mimeType: "image/jpeg" }] },
-        createTestDeps({
-          extractWithAi: async () => null,
-        }),
-      ),
-    ).rejects.toThrow("Kunde inte extrahera något recept från bilderna");
-  });
-
   it("propagates fetchHtml errors", async () => {
     await expect(
-      importRecipe(
-        { kind: "url", url: "https://example.com/down" },
-        createTestDeps({
+      importFromUrl(
+        "https://example.com/down",
+        createTestDeps(),
+        urlStubs({
           fetchHtml: async () => {
             throw new Error("Kunde inte hämta sidan (500)");
           },
         }),
       ),
     ).rejects.toThrow("Kunde inte hämta sidan (500)");
+  });
+});
+
+describe("importFromPhotos", () => {
+  it("extracts recipe from photos via OCR", async () => {
+    const ocrDraft: RecipeDraft = {
+      title: "Fotograferat recept",
+      description: null,
+      ingredients: [{ group: null, items: ["2 dl grädde"] }],
+      steps: ["Vispa grädden"],
+      cookingTimeMinutes: null,
+      servings: null,
+      suggestedTagNames: null,
+    };
+
+    const images = [{ base64: "abc123", mimeType: "image/jpeg" }];
+
+    const result = await importFromPhotos(images, createTestDeps(), {
+      extractWithAi: async (input) => {
+        expect(input.kind).toBe("images");
+        if (input.kind === "images") {
+          expect(input.images).toEqual(images);
+        }
+        return ocrDraft;
+      },
+    });
+
+    expect(result.draft.title).toBe("Fotograferat recept");
+    expect(result.extraction).toBe("ocr");
+  });
+
+  it("throws when OCR extraction returns null", async () => {
+    await expect(
+      importFromPhotos(
+        [{ base64: "abc", mimeType: "image/jpeg" }],
+        createTestDeps(),
+        {
+          extractWithAi: async () => null,
+        },
+      ),
+    ).rejects.toThrow("Kunde inte extrahera något recept från bilderna");
   });
 });

--- a/src/import/classify-tags.ts
+++ b/src/import/classify-tags.ts
@@ -1,0 +1,44 @@
+import OpenAI from "openai";
+
+export type ClassifyTagsInput = {
+  title: string;
+  description: string | null;
+  ingredients: string[];
+};
+
+export const classifyRecipeTags = async (
+  recipe: ClassifyTagsInput,
+  tagNames: string[],
+  apiKey: string,
+): Promise<string[]> => {
+  const client = new OpenAI({ apiKey });
+
+  const ingredientList = recipe.ingredients.join(", ");
+  const description = recipe.description ?? "";
+
+  const completion = await client.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [
+      {
+        role: "system",
+        content: `Du är en receptklassificerare. Givet ett recepts titel, beskrivning och ingredienser, välj de taggar som passar bäst från listan.\n\nSvara med en JSON-array av strängar, t.ex. ["Fisk", "Vardag"]. Välj bara taggar från listan. Om inga taggar passar, svara med en tom array [].`,
+      },
+      {
+        role: "user",
+        content: `Recept: ${recipe.title}\nBeskrivning: ${description}\nIngredienser: ${ingredientList}\n\nTillgängliga taggar: ${tagNames.join(", ")}`,
+      },
+    ],
+    response_format: { type: "json_object" },
+  });
+
+  const content = completion.choices[0].message.content;
+  if (!content) return [];
+
+  try {
+    const parsed = JSON.parse(content);
+    const tags = Array.isArray(parsed) ? parsed : parsed.tags ?? [];
+    return tags.filter((t: unknown): t is string => typeof t === "string");
+  } catch {
+    return [];
+  }
+};

--- a/src/import/pipeline.ts
+++ b/src/import/pipeline.ts
@@ -1,26 +1,23 @@
 import type { Database } from "#/db/types";
+import {
+  classifyRecipeTags,
+  type ClassifyTagsInput,
+} from "#/import/classify-tags";
 import { extractImageUrl, extractJsonLdRecipe } from "#/import/extract";
 import type { RecipeDraft } from "#/import/schema";
 import { getAllTags } from "#/tags/crud";
 import { validatePublicUrl } from "#/utils/url-validation";
 
-export type ImportSource =
-  | { kind: "url"; url: string }
-  | { kind: "photos"; images: Array<{ base64: string; mimeType: string }> };
-
 export type AiExtractionInput =
   | { kind: "html"; html: string }
   | { kind: "images"; images: Array<{ base64: string; mimeType: string }> };
 
-export type ClassifyTagsInput = {
-  title: string;
-  description: string | null;
-  ingredients: string[];
-};
-
 export type ImportDeps = {
   db: Database;
   openaiApiKey: string;
+};
+
+export type ImportTestOverrides = {
   fetchHtml?: (url: string) => Promise<string>;
   extractWithAi?: (
     input: AiExtractionInput,
@@ -33,35 +30,41 @@ export type ImportDeps = {
   storeImage?: (url: string) => Promise<string | null>;
 };
 
-export type ImportResult = {
+export type UrlImportResult = {
   draft: RecipeDraft;
   tagIds: number[];
   imageUrl: string | null;
-  sourceUrl?: string;
-  extraction: "json-ld" | "ai" | "ocr";
+  sourceUrl: string;
+  extraction: "json-ld" | "ai";
 };
 
-export const importRecipe = async (
-  source: ImportSource,
-  deps: ImportDeps,
-): Promise<ImportResult> => {
-  if (source.kind === "url") {
-    return importFromUrl(source.url, deps);
-  }
-
-  return importFromPhotos(source.images, deps);
+export type PhotoImportResult = {
+  draft: RecipeDraft;
+  tagIds: number[];
+  extraction: "ocr";
 };
 
-const importFromUrl = async (
+type ClassifyTagsFn = (
+  recipe: ClassifyTagsInput,
+  tagNames: string[],
+) => Promise<string[]>;
+
+type ExtractWithAiFn = (
+  input: AiExtractionInput,
+  tagNames: string[],
+) => Promise<RecipeDraft | null>;
+
+export const importFromUrl = async (
   url: string,
   deps: ImportDeps,
-): Promise<ImportResult> => {
-  const fetchHtml = deps.fetchHtml ?? defaultFetchHtml;
+  overrides: ImportTestOverrides = {},
+): Promise<UrlImportResult> => {
+  const fetchHtml = overrides.fetchHtml ?? defaultFetchHtml;
   const extractWithAi =
-    deps.extractWithAi ?? defaultExtractWithAi(deps.openaiApiKey);
+    overrides.extractWithAi ?? defaultExtractWithAi(deps.openaiApiKey);
   const classifyTags =
-    deps.classifyTags ?? defaultClassifyTags(deps.openaiApiKey);
-  const storeImage = deps.storeImage ?? defaultStoreImage;
+    overrides.classifyTags ?? defaultClassifyTags(deps.openaiApiKey);
+  const storeImage = overrides.storeImage ?? defaultStoreImage;
 
   const tags = await getAllTags(deps.db);
   const tagNames = tags.map((t) => t.name);
@@ -101,6 +104,34 @@ const importFromUrl = async (
   throw new Error("Kunde inte extrahera något recept från den angivna sidan");
 };
 
+export const importFromPhotos = async (
+  images: Array<{ base64: string; mimeType: string }>,
+  deps: ImportDeps,
+  overrides: ImportTestOverrides = {},
+): Promise<PhotoImportResult> => {
+  const extractWithAi =
+    overrides.extractWithAi ?? defaultExtractWithAi(deps.openaiApiKey);
+  const classifyTags =
+    overrides.classifyTags ?? defaultClassifyTags(deps.openaiApiKey);
+
+  const tags = await getAllTags(deps.db);
+  const tagNames = tags.map((t) => t.name);
+
+  const draft = await extractWithAi({ kind: "images", images }, tagNames);
+
+  if (!draft) {
+    throw new Error("Kunde inte extrahera något recept från bilderna");
+  }
+
+  const tagIds = await resolveTagIds(draft, tags, classifyTags);
+
+  return {
+    draft,
+    tagIds,
+    extraction: "ocr",
+  };
+};
+
 const matchTagNames = (
   suggestedNames: string[],
   tags: Array<{ id: number; name: string }>,
@@ -116,10 +147,7 @@ const matchTagNames = (
 const resolveTagIds = async (
   draft: RecipeDraft,
   tags: Array<{ id: number; name: string }>,
-  classifyTags: (
-    recipe: ClassifyTagsInput,
-    tagNames: string[],
-  ) => Promise<string[]>,
+  classifyTags: ClassifyTagsFn,
 ): Promise<number[]> => {
   if (draft.suggestedTagNames && draft.suggestedTagNames.length > 0) {
     return matchTagNames(draft.suggestedTagNames, tags);
@@ -145,34 +173,6 @@ const resolveTagIds = async (
   return [];
 };
 
-const importFromPhotos = async (
-  images: Array<{ base64: string; mimeType: string }>,
-  deps: ImportDeps,
-): Promise<ImportResult> => {
-  const extractWithAi =
-    deps.extractWithAi ?? defaultExtractWithAi(deps.openaiApiKey);
-  const classifyTags =
-    deps.classifyTags ?? defaultClassifyTags(deps.openaiApiKey);
-
-  const tags = await getAllTags(deps.db);
-  const tagNames = tags.map((t) => t.name);
-
-  const draft = await extractWithAi({ kind: "images", images }, tagNames);
-
-  if (!draft) {
-    throw new Error("Kunde inte extrahera något recept från bilderna");
-  }
-
-  const tagIds = await resolveTagIds(draft, tags, classifyTags);
-
-  return {
-    draft,
-    tagIds,
-    imageUrl: null,
-    extraction: "ocr",
-  };
-};
-
 const resolveImageUrl = async (
   html: string,
   storeImage: (url: string) => Promise<string | null>,
@@ -188,11 +188,8 @@ const defaultStoreImage = async (url: string): Promise<string | null> => {
 };
 
 const defaultExtractWithAi =
-  (apiKey: string) =>
-  async (
-    input: AiExtractionInput,
-    tagNames: string[],
-  ): Promise<RecipeDraft | null> => {
+  (apiKey: string): ExtractWithAiFn =>
+  async (input, tagNames) => {
     if (input.kind === "html") {
       const { extractRecipeWithAi } = await import("#/import/ai-extract");
       return extractRecipeWithAi(input.html, tagNames, apiKey);
@@ -202,43 +199,9 @@ const defaultExtractWithAi =
   };
 
 const defaultClassifyTags =
-  (apiKey: string) =>
-  async (
-    recipe: ClassifyTagsInput,
-    tagNames: string[],
-  ): Promise<string[]> => {
-    const OpenAI = (await import("openai")).default;
-    const client = new OpenAI({ apiKey });
-
-    const ingredientList = recipe.ingredients.join(", ");
-    const description = recipe.description ?? "";
-
-    const completion = await client.chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [
-        {
-          role: "system",
-          content: `Du är en receptklassificerare. Givet ett recepts titel, beskrivning och ingredienser, välj de taggar som passar bäst från listan.\n\nSvara med en JSON-array av strängar, t.ex. ["Fisk", "Vardag"]. Välj bara taggar från listan. Om inga taggar passar, svara med en tom array [].`,
-        },
-        {
-          role: "user",
-          content: `Recept: ${recipe.title}\nBeskrivning: ${description}\nIngredienser: ${ingredientList}\n\nTillgängliga taggar: ${tagNames.join(", ")}`,
-        },
-      ],
-      response_format: { type: "json_object" },
-    });
-
-    const content = completion.choices[0].message.content;
-    if (!content) return [];
-
-    try {
-      const parsed = JSON.parse(content);
-      const tags = Array.isArray(parsed) ? parsed : parsed.tags ?? [];
-      return tags.filter((t: unknown): t is string => typeof t === "string");
-    } catch {
-      return [];
-    }
-  };
+  (apiKey: string): ClassifyTagsFn =>
+  (recipe, tagNames) =>
+    classifyRecipeTags(recipe, tagNames, apiKey);
 
 const defaultFetchHtml = async (url: string): Promise<string> => {
   validatePublicUrl(url);

--- a/src/import/server.ts
+++ b/src/import/server.ts
@@ -1,5 +1,5 @@
 import { getDb } from "#/db/client";
-import { importRecipe } from "#/import/pipeline";
+import { importFromPhotos, importFromUrl } from "#/import/pipeline";
 import { createServerFn } from "@tanstack/react-start";
 import { env } from "cloudflare:workers";
 import { z } from "zod";
@@ -8,18 +8,12 @@ import { authMiddleware } from "#/auth/middleware";
 export const extractRecipeFromUrl = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(z.object({ url: z.string().url() }))
-  .handler(async ({ data }) => {
-    const result = await importRecipe(
-      { kind: "url", url: data.url },
-      { db: getDb(), openaiApiKey: env.OPENAI_API_KEY },
-    );
-    return {
-      ...result.draft,
-      sourceUrl: result.sourceUrl,
-      tagIds: result.tagIds,
-      imageUrl: result.imageUrl,
-    };
-  });
+  .handler(({ data }) =>
+    importFromUrl(data.url, {
+      db: getDb(),
+      openaiApiKey: env.OPENAI_API_KEY,
+    }),
+  );
 
 export const extractRecipeFromPhotos = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
@@ -35,10 +29,9 @@ export const extractRecipeFromPhotos = createServerFn({ method: "POST" })
         .min(1),
     }),
   )
-  .handler(async ({ data }) => {
-    const result = await importRecipe(
-      { kind: "photos", images: data.images },
-      { db: getDb(), openaiApiKey: env.OPENAI_API_KEY },
-    );
-    return { ...result.draft, tagIds: result.tagIds };
-  });
+  .handler(({ data }) =>
+    importFromPhotos(data.images, {
+      db: getDb(),
+      openaiApiKey: env.OPENAI_API_KEY,
+    }),
+  );

--- a/src/routes/_authed/import.tsx
+++ b/src/routes/_authed/import.tsx
@@ -33,7 +33,7 @@ const ImportPage = () => {
     try {
       const result = await extractRecipeFromUrl({ data: { url: url.trim() } })
       setImportMeta({ sourceUrl: result.sourceUrl, imageUrl: result.imageUrl ?? undefined })
-      setPreviewData(Recipe.fromDraft(result))
+      setPreviewData(Recipe.fromDraft({ ...result.draft, tagIds: result.tagIds }))
     } catch {
       setError('Kunde inte hämta recept från den angivna URL:en. Prova att lägga till manuellt istället.')
     } finally {
@@ -170,7 +170,7 @@ const PhotoImport = ({ onExtracted, onError }: PhotoImportProps) => {
 
       const result = await extractRecipeFromPhotos({ data: { images } })
 
-      onExtracted(Recipe.fromDraft(result))
+      onExtracted(Recipe.fromDraft({ ...result.draft, tagIds: result.tagIds }))
     } catch {
       onError('Kunde inte extrahera recept från bilderna. Försök med tydligare bilder eller lägg till manuellt.')
     } finally {


### PR DESCRIPTION
## Summary

Closes #143. Deepens the import pipeline module by splitting the conflated `importRecipe` entry point into two caller-optimized functions and separating production config from test overrides.

- Split `importRecipe` into `importFromUrl` and `importFromPhotos` with narrowed return types (`UrlImportResult` / `PhotoImportResult`)
- Split `ImportDeps` into required production config and an optional `ImportTestOverrides` third argument -- test stubs no longer leak into the production type
- Extract `defaultClassifyTags` into its own `classify-tags.ts` module, matching the pattern of `ai-extract.ts` and `ocr-extract.ts`
- Simplify `server.ts` handlers -- they now return the pipeline result directly without reshaping
- Update the import route to handle the nested `draft` field
- Migrate pipeline tests into two `describe` blocks; photo tests no longer mention `fetchHtml` or `storeImage`

## Test plan

- [x] `npm test` -- all 147 tests pass
- [x] `npm run typecheck` -- clean
- [x] `npm run lint` -- no new warnings
- [ ] Manual smoke test: import recipe from URL in dev
- [ ] Manual smoke test: import recipe from photos in dev