### PR TITLE
Split chat service into testable engine and HTTP skin

### DIFF
--- a/src/auth/parse-cookie.ts
+++ b/src/auth/parse-cookie.ts
@@ -1,0 +1,10 @@
+/**
+ * Parse a named cookie value from a raw Cookie header string.
+ *
+ * Used in raw route handlers where `getCookie` (from `@tanstack/react-start/server`)
+ * isn't available. Prefer `authMiddleware` for server functions.
+ */
+export const parseCookie = (cookieHeader: string, name: string): string | undefined => {
+  const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`))
+  return match?.[1]
+}

--- a/src/chat/__tests__/engine.test.ts
+++ b/src/chat/__tests__/engine.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { AnyTextAdapter, StreamChunk, TextOptions } from '@tanstack/ai'
+import { createChatEngine, SYSTEM_PROMPT } from '#/chat/engine'
+import { createTestDb, createTestRecipe, createTestTag } from '#/test-utils'
+import { getMenu, addToMenu } from '#/menu/crud'
+
+type ChatStreamSpy = ReturnType<typeof vi.fn<(options: TextOptions) => AsyncIterable<StreamChunk>>>
+
+const createFakeAdapter = () => {
+  const chatStream: ChatStreamSpy = vi.fn((_options) => {
+    return (async function* () {
+      // No-op stream. Tests inspect the call args, not the output.
+    })()
+  })
+
+  const adapter = {
+    kind: 'text',
+    name: 'fake',
+    model: 'fake-model',
+    '~types': {} as AnyTextAdapter['~types'],
+    chatStream,
+    structuredOutput: vi.fn(),
+  } as unknown as AnyTextAdapter
+
+  return { adapter, chatStream }
+}
+
+const consume = async (stream: AsyncIterable<StreamChunk>) => {
+  const chunks: StreamChunk[] = []
+  for await (const chunk of stream) chunks.push(chunk)
+  return chunks
+}
+
+describe('createChatEngine', () => {
+  it('includes the full system prompt in the adapter call', async () => {
+    const db = createTestDb()
+    const { adapter, chatStream } = createFakeAdapter()
+
+    const engine = createChatEngine({ db, adapter })
+    await consume(
+      await engine.chat({
+        messages: [{ role: 'user', content: 'Hej!' }],
+        conversationId: 'conv-1',
+      }),
+    )
+
+    expect(chatStream).toHaveBeenCalledTimes(1)
+    const options = chatStream.mock.calls[0][0]
+    expect(options.systemPrompts).toHaveLength(1)
+    expect(options.systemPrompts?.[0]).toContain(SYSTEM_PROMPT)
+  })
+
+  it('includes recipe titles and ids in the system prompt', async () => {
+    const db = createTestDb()
+    await createTestRecipe(db, { title: 'Pasta Carbonara' })
+    await createTestRecipe(db, { title: 'Köttbullar med potatismos' })
+    const { adapter, chatStream } = createFakeAdapter()
+
+    const engine = createChatEngine({ db, adapter })
+    await consume(
+      await engine.chat({
+        messages: [{ role: 'user', content: 'Vad kan jag laga?' }],
+        conversationId: 'conv-2',
+      }),
+    )
+
+    const systemPrompt = chatStream.mock.calls[0][0].systemPrompts?.[0] ?? ''
+    expect(systemPrompt).toContain('Pasta Carbonara')
+    expect(systemPrompt).toContain('Köttbullar med potatismos')
+    expect(systemPrompt).toContain('RECEPTSAMLING (2 recept)')
+  })
+
+  it('reflects recipe changes between calls (recipes loaded per request)', async () => {
+    const db = createTestDb()
+    const { adapter, chatStream } = createFakeAdapter()
+    const engine = createChatEngine({ db, adapter })
+
+    await consume(
+      await engine.chat({ messages: [{ role: 'user', content: 'först' }], conversationId: 'a' }),
+    )
+    const firstPrompt = chatStream.mock.calls[0][0].systemPrompts?.[0] ?? ''
+    expect(firstPrompt).toContain('Receptsamlingen är tom.')
+
+    await createTestRecipe(db, { title: 'Lax i ugn' })
+
+    await consume(
+      await engine.chat({ messages: [{ role: 'user', content: 'igen' }], conversationId: 'b' }),
+    )
+    const secondPrompt = chatStream.mock.calls[1][0].systemPrompts?.[0] ?? ''
+    expect(secondPrompt).toContain('Lax i ugn')
+  })
+
+  it('handles an empty recipe collection gracefully', async () => {
+    const db = createTestDb()
+    const { adapter, chatStream } = createFakeAdapter()
+
+    const engine = createChatEngine({ db, adapter })
+    await consume(
+      await engine.chat({
+        messages: [{ role: 'user', content: 'Hej!' }],
+        conversationId: 'conv-empty',
+      }),
+    )
+
+    const systemPrompt = chatStream.mock.calls[0][0].systemPrompts?.[0] ?? ''
+    expect(systemPrompt).toContain('Receptsamlingen är tom.')
+    expect(systemPrompt).toContain('RECEPTSAMLING (0 recept)')
+  })
+
+  it('forwards user and assistant messages to the adapter', async () => {
+    const db = createTestDb()
+    const { adapter, chatStream } = createFakeAdapter()
+
+    const engine = createChatEngine({ db, adapter })
+    await consume(
+      await engine.chat({
+        messages: [
+          { role: 'user', content: 'Hej!' },
+          { role: 'assistant', content: 'Hej tillbaka!' },
+          { role: 'user', content: 'Vad kan jag laga?' },
+        ],
+        conversationId: 'conv-forward',
+      }),
+    )
+
+    const forwardedMessages = chatStream.mock.calls[0][0].messages
+    const contents = forwardedMessages.map((m) => m.content)
+    expect(contents).toContain('Hej!')
+    expect(contents).toContain('Hej tillbaka!')
+    expect(contents).toContain('Vad kan jag laga?')
+  })
+
+  it('registers get_weekly_menu and add_to_weekly_menu tools', async () => {
+    const db = createTestDb()
+    const { adapter, chatStream } = createFakeAdapter()
+
+    const engine = createChatEngine({ db, adapter })
+    await consume(
+      await engine.chat({
+        messages: [{ role: 'user', content: 'Visa veckomenyn' }],
+        conversationId: 'conv-tools',
+      }),
+    )
+
+    const tools = chatStream.mock.calls[0][0].tools ?? []
+    const toolNames = tools.map((t) => t.name)
+    expect(toolNames).toEqual(['get_weekly_menu', 'add_to_weekly_menu'])
+  })
+
+  it('get_weekly_menu tool returns menu items from the database', async () => {
+    const db = createTestDb()
+    const tag = await createTestTag(db, 'Snabblagat')
+    const recipe = await createTestRecipe(db, {
+      title: 'Pasta Carbonara',
+      cookingTimeMinutes: 25,
+      servings: 4,
+      tagIds: [tag.id],
+    })
+    await addToMenu(db, recipe.id)
+
+    const { adapter, chatStream } = createFakeAdapter()
+    const engine = createChatEngine({ db, adapter })
+    await consume(
+      await engine.chat({
+        messages: [{ role: 'user', content: 'menu?' }],
+        conversationId: 'conv-menu',
+      }),
+    )
+
+    const tools = chatStream.mock.calls[0][0].tools ?? []
+    const getMenuTool = tools.find((t) => t.name === 'get_weekly_menu')!
+    const result = await getMenuTool.execute!({})
+
+    expect(result).toEqual([
+      {
+        recipeId: recipe.id,
+        title: 'Pasta Carbonara',
+        cookingTimeMinutes: 25,
+        servings: 4,
+        cooked: false,
+      },
+    ])
+  })
+
+  it('add_to_weekly_menu tool adds a recipe to the menu', async () => {
+    const db = createTestDb()
+    const recipe = await createTestRecipe(db, { title: 'Lax i ugn' })
+
+    const { adapter, chatStream } = createFakeAdapter()
+    const engine = createChatEngine({ db, adapter })
+    await consume(
+      await engine.chat({
+        messages: [{ role: 'user', content: 'lägg till' }],
+        conversationId: 'conv-add',
+      }),
+    )
+
+    const tools = chatStream.mock.calls[0][0].tools ?? []
+    const addTool = tools.find((t) => t.name === 'add_to_weekly_menu')!
+    const result = await addTool.execute!({ recipeId: recipe.id })
+
+    expect(result).toEqual({ success: true, message: 'Receptet har lagts till i veckomenyn.' })
+    const menu = await getMenu(db)
+    expect(menu).toHaveLength(1)
+    expect(menu[0].recipe.id).toBe(recipe.id)
+  })
+})

--- a/src/chat/__tests__/service.test.ts
+++ b/src/chat/__tests__/service.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { AnyTextAdapter, StreamChunk, TextOptions } from '@tanstack/ai'
+import { createChatService } from '#/chat/service'
+import { createTestDb } from '#/test-utils'
+
+const chatStreamSpy = vi.fn<(options: TextOptions) => AsyncIterable<StreamChunk>>(() =>
+  (async function* () {
+    // Empty stream. Service tests only verify the HTTP plumbing.
+  })(),
+)
+const createOpenaiChatSpy = vi.fn<(model: string, apiKey: string) => void>()
+
+vi.mock('@tanstack/ai-openai', () => ({
+  createOpenaiChat: (model: string, apiKey: string) => {
+    createOpenaiChatSpy(model, apiKey)
+    return {
+      kind: 'text',
+      name: 'openai',
+      model,
+      '~types': {} as AnyTextAdapter['~types'],
+      chatStream: chatStreamSpy,
+      structuredOutput: vi.fn(),
+    } as unknown as AnyTextAdapter
+  },
+}))
+
+const buildRequest = (body: unknown) =>
+  new Request('https://example.test/api/chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+describe('createChatService', () => {
+  beforeEach(() => {
+    chatStreamSpy.mockClear()
+    createOpenaiChatSpy.mockClear()
+  })
+
+  it('returns a Server-Sent Events response', async () => {
+    const db = createTestDb()
+    const service = createChatService({ db, openaiApiKey: 'test-key' })
+
+    const response = await service.handleRequest(
+      buildRequest({
+        messages: [{ role: 'user', content: 'Hej!' }],
+        conversationId: 'conv-1',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+  })
+
+  it('constructs the OpenAI adapter with the configured api key and model', async () => {
+    const db = createTestDb()
+    const service = createChatService({ db, openaiApiKey: 'sk-test-123' })
+
+    await service.handleRequest(
+      buildRequest({
+        messages: [{ role: 'user', content: 'Hej!' }],
+        conversationId: 'conv-2',
+      }),
+    )
+
+    expect(createOpenaiChatSpy).toHaveBeenCalledWith('gpt-4.1-mini', 'sk-test-123')
+  })
+
+  it('parses the JSON body and forwards messages to the engine/adapter', async () => {
+    const db = createTestDb()
+    const service = createChatService({ db, openaiApiKey: 'test-key' })
+
+    const response = await service.handleRequest(
+      buildRequest({
+        messages: [{ role: 'user', content: 'Recept på carbonara?' }],
+        conversationId: 'conv-body',
+      }),
+    )
+    // Drain the SSE stream so the engine actually pulls from the adapter.
+    await response.text()
+
+    expect(chatStreamSpy).toHaveBeenCalledTimes(1)
+    const forwardedMessages = chatStreamSpy.mock.calls[0]![0].messages
+    const contents = forwardedMessages.map((m) => m.content)
+    expect(contents).toContain('Recept på carbonara?')
+  })
+})

--- a/src/chat/engine.ts
+++ b/src/chat/engine.ts
@@ -1,0 +1,46 @@
+import { chat, maxIterations } from '@tanstack/ai'
+import type { StreamChunk } from '@tanstack/ai'
+import { getAllRecipes } from '#/recipes/crud'
+import { buildRecipeIndex } from '#/chat/recipe-index'
+import { createTools } from '#/chat/tools'
+import type { ChatEngineDeps, ChatInput } from '#/chat/types'
+
+export const SYSTEM_PROMPT = `Du är Tallrikens receptassistent. Du hjälper användaren att hitta recept, planera veckomenyer, skapa inköpslistor och skala recept.
+
+Du har tillgång till HELA användarens receptsamling nedan. Använd den direkt for att svara på frågor om recept.
+
+Regler:
+- Svara alltid på svenska
+- Skapa markdown-länkar med receptets URL. Exempel: om ett recept har ID 5 och titel "Pasta Carbonara", skriv [Pasta Carbonara](/recipes/5)
+- När du presenterar recept, lista ALLA relevanta träffar med en kort beskrivning och länk
+- Ge en kort beskrivning men länka till receptet istället för att skriva ut hela, om inte användaren explicit ber om detaljer
+- Var kortfattad och tydlig
+- Formatera inköpslistor och veckomenyer på ett lättläst sätt med markdown
+- Basera ALLA förslag på receptsamlingen nedan. Hitta aldrig på recept.
+- Du kan bedöma kosttyp genom att titta på ingredienserna i receptlistan.
+- Om meddelandet börjar med [KONTEXT: ...] innehåller det information om vilken sida användaren befinner sig på. Använd den informationen för att förstå vad användaren syftar på med "det här receptet" eller liknande.
+
+VIKTIGT om veckomenyn:
+- Verktyget get_weekly_menu hämtar aktuella planerade recept.
+- Verktyget add_to_weekly_menu lägger till ett recept via dess ID.`
+
+export type ChatEngine = {
+  chat: (input: ChatInput) => Promise<AsyncIterable<StreamChunk>>
+}
+
+export const createChatEngine = (deps: ChatEngineDeps): ChatEngine => ({
+  chat: async (input) => {
+    const recipes = await getAllRecipes(deps.db)
+    const recipeIndex = buildRecipeIndex(recipes)
+    const tools = createTools(deps.db)
+
+    return chat({
+      adapter: deps.adapter,
+      systemPrompts: [SYSTEM_PROMPT + `\n\nRECEPTSAMLING (${recipes.length} recept):\n\n` + recipeIndex],
+      messages: input.messages,
+      conversationId: input.conversationId,
+      tools,
+      agentLoopStrategy: maxIterations(12),
+    })
+  },
+})

--- a/src/chat/service.ts
+++ b/src/chat/service.ts
@@ -1,116 +1,28 @@
-import { chat, toServerSentEventsResponse, maxIterations } from '@tanstack/ai'
+import { toServerSentEventsResponse } from '@tanstack/ai'
 import { createOpenaiChat } from '@tanstack/ai-openai'
-import { toolDefinition } from '@tanstack/ai'
-import { z } from 'zod'
 import type { Database } from '#/db/types'
-import { validateSessionToken } from '#/auth/session'
-import { SESSION_COOKIE_NAME } from '#/auth/cookies'
-import { getAllRecipes } from '#/recipes/crud'
-import { getMenu, addToMenu } from '#/menu/crud'
-import { buildRecipeIndex } from '#/chat/recipe-index'
+import { createChatEngine } from '#/chat/engine'
+import type { ChatInput } from '#/chat/types'
 
-export type ChatDeps = {
+export type ChatServiceDeps = {
   db: Database
   openaiApiKey: string
-  appSecret: string
 }
 
 export type ChatService = {
   handleRequest: (request: Request) => Promise<Response>
 }
 
-const SYSTEM_PROMPT = `Du är Tallrikens receptassistent. Du hjälper användaren att hitta recept, planera veckomenyer, skapa inköpslistor och skala recept.
+export const createChatService = (deps: ChatServiceDeps): ChatService => ({
+  handleRequest: async (request) => {
+    const { messages, conversationId } = (await request.json()) as ChatInput
 
-Du har tillgång till HELA användarens receptsamling nedan. Använd den direkt for att svara på frågor om recept.
-
-Regler:
-- Svara alltid på svenska
-- Skapa markdown-länkar med receptets URL. Exempel: om ett recept har ID 5 och titel "Pasta Carbonara", skriv [Pasta Carbonara](/recipes/5)
-- När du presenterar recept, lista ALLA relevanta träffar med en kort beskrivning och länk
-- Ge en kort beskrivning men länka till receptet istället för att skriva ut hela, om inte användaren explicit ber om detaljer
-- Var kortfattad och tydlig
-- Formatera inköpslistor och veckomenyer på ett lättläst sätt med markdown
-- Basera ALLA förslag på receptsamlingen nedan. Hitta aldrig på recept.
-- Du kan bedöma kosttyp genom att titta på ingredienserna i receptlistan.
-- Om meddelandet börjar med [KONTEXT: ...] innehåller det information om vilken sida användaren befinner sig på. Använd den informationen för att förstå vad användaren syftar på med "det här receptet" eller liknande.
-
-VIKTIGT om veckomenyn:
-- Verktyget get_weekly_menu hämtar aktuella planerade recept.
-- Verktyget add_to_weekly_menu lägger till ett recept via dess ID.`
-
-const createTools = (db: Database) => {
-  const getWeeklyMenuDef = toolDefinition({
-    name: 'get_weekly_menu',
-    description:
-      'Hämta användarens veckomeny. Returnerar alla planerade recept med titel, tillagningstid, portioner och om de är tillagade.',
-    inputSchema: z.object({}),
-  })
-
-  const getWeeklyMenuTool = getWeeklyMenuDef.server(async () => {
-    const menu = await getMenu(db)
-    return menu.map((item) => ({
-      recipeId: item.recipe.id,
-      title: item.recipe.title,
-      cookingTimeMinutes: item.recipe.cookingTimeMinutes,
-      servings: item.recipe.servings,
-      cooked: !!item.completedAt,
-    }))
-  })
-
-  const addToWeeklyMenuDef = toolDefinition({
-    name: 'add_to_weekly_menu',
-    description:
-      'Lägg till ett recept i användarens veckomeny. Tar ett recept-ID. Returnerar bekräftelse eller felmeddelande om receptet redan finns i menyn.',
-    inputSchema: z.object({
-      recipeId: z.number().describe('ID för receptet som ska läggas till'),
-    }),
-  })
-
-  const addToWeeklyMenuTool = addToWeeklyMenuDef.server(async ({ recipeId }) => {
-    try {
-      await addToMenu(db, recipeId)
-      return { success: true, message: `Receptet har lagts till i veckomenyn.` }
-    } catch {
-      return { success: false, message: `Kunde inte lägga till receptet. Kontrollera att recept-ID:t är korrekt.` }
-    }
-  })
-
-  return [getWeeklyMenuTool, addToWeeklyMenuTool]
-}
-
-const parseCookie = (cookieHeader: string, name: string): string | undefined => {
-  const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`))
-  return match?.[1]
-}
-
-export const createChatService = (deps: ChatDeps): ChatService => ({
-  handleRequest: async (request: Request): Promise<Response> => {
-    const cookieHeader = request.headers.get('cookie') ?? ''
-    const sessionToken = parseCookie(cookieHeader, SESSION_COOKIE_NAME)
-
-    if (!sessionToken || !validateSessionToken(sessionToken, deps.appSecret)) {
-      return new Response('Unauthorized', { status: 401 })
-    }
-
-    const { messages, conversationId } = (await request.json()) as {
-      messages: Array<{ role: 'user' | 'assistant' | 'tool'; content: string }>
-      conversationId: string
-    }
-
-    const recipes = await getAllRecipes(deps.db)
-    const recipeIndex = buildRecipeIndex(recipes)
-
-    const tools = createTools(deps.db)
-
-    const stream = chat({
+    const engine = createChatEngine({
+      db: deps.db,
       adapter: createOpenaiChat('gpt-4.1-mini', deps.openaiApiKey),
-      systemPrompts: [SYSTEM_PROMPT + `\n\nRECEPTSAMLING (${recipes.length} recept):\n\n` + recipeIndex],
-      messages,
-      conversationId,
-      tools,
-      agentLoopStrategy: maxIterations(12),
     })
 
+    const stream = await engine.chat({ messages, conversationId })
     return toServerSentEventsResponse(stream)
   },
 })

--- a/src/chat/tools.ts
+++ b/src/chat/tools.ts
@@ -1,0 +1,44 @@
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+import type { Database } from '#/db/types'
+import { getMenu, addToMenu } from '#/menu/crud'
+
+export const createTools = (db: Database) => {
+  const getWeeklyMenuDef = toolDefinition({
+    name: 'get_weekly_menu',
+    description:
+      'Hämta användarens veckomeny. Returnerar alla planerade recept med titel, tillagningstid, portioner och om de är tillagade.',
+    inputSchema: z.object({}),
+  })
+
+  const getWeeklyMenuTool = getWeeklyMenuDef.server(async () => {
+    const menu = await getMenu(db)
+    return menu.map((item) => ({
+      recipeId: item.recipe.id,
+      title: item.recipe.title,
+      cookingTimeMinutes: item.recipe.cookingTimeMinutes,
+      servings: item.recipe.servings,
+      cooked: !!item.completedAt,
+    }))
+  })
+
+  const addToWeeklyMenuDef = toolDefinition({
+    name: 'add_to_weekly_menu',
+    description:
+      'Lägg till ett recept i användarens veckomeny. Tar ett recept-ID. Returnerar bekräftelse eller felmeddelande om receptet redan finns i menyn.',
+    inputSchema: z.object({
+      recipeId: z.number().describe('ID för receptet som ska läggas till'),
+    }),
+  })
+
+  const addToWeeklyMenuTool = addToWeeklyMenuDef.server(async ({ recipeId }) => {
+    try {
+      await addToMenu(db, recipeId)
+      return { success: true, message: `Receptet har lagts till i veckomenyn.` }
+    } catch {
+      return { success: false, message: `Kunde inte lägga till receptet. Kontrollera att recept-ID:t är korrekt.` }
+    }
+  })
+
+  return [getWeeklyMenuTool, addToWeeklyMenuTool]
+}

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -1,0 +1,17 @@
+import type { AnyTextAdapter } from '@tanstack/ai'
+import type { Database } from '#/db/types'
+
+export type ChatMessage = {
+  role: 'user' | 'assistant' | 'tool'
+  content: string
+}
+
+export type ChatInput = {
+  messages: ChatMessage[]
+  conversationId: string
+}
+
+export type ChatEngineDeps = {
+  db: Database
+  adapter: AnyTextAdapter
+}

--- a/src/routes/api/chat.ts
+++ b/src/routes/api/chat.ts
@@ -2,15 +2,24 @@ import { createFileRoute } from '@tanstack/react-router'
 import { env } from 'cloudflare:workers'
 import { getDb } from '#/db/client'
 import { createChatService } from '#/chat/service'
+import { validateSessionToken } from '#/auth/session'
+import { SESSION_COOKIE_NAME } from '#/auth/cookies'
+import { parseCookie } from '#/auth/parse-cookie'
 
 export const Route = createFileRoute('/api/chat')({
   server: {
     handlers: {
       POST: async ({ request }) => {
+        const cookieHeader = request.headers.get('cookie') ?? ''
+        const sessionToken = parseCookie(cookieHeader, SESSION_COOKIE_NAME)
+
+        if (!sessionToken || !validateSessionToken(sessionToken, env.APP_SECRET)) {
+          return new Response('Unauthorized', { status: 401 })
+        }
+
         const service = createChatService({
           db: getDb(),
           openaiApiKey: env.OPENAI_API_KEY,
-          appSecret: env.APP_SECRET,
         })
         return service.handleRequest(request)
       },


### PR DESCRIPTION
## Summary
- Split `src/chat/service.ts` (117 rader) into a testable `createChatEngine` (adapter injected) + a thin `createChatService` HTTP wrapper
- Moved auth out of the chat module: cookie validation now lives in the `/api/chat` route handler, matching the pattern used by every other endpoint. `appSecret` is no longer part of `ChatServiceDeps`
- Extracted tools (`get_weekly_menu`, `add_to_weekly_menu`) into `src/chat/tools.ts` and added a shared `parseCookie` helper in `src/auth/` for raw route handlers
- Added 11 new tests (8 engine, 3 service) covering system prompt assembly, recipe index, tool execution, SSE response, OpenAI adapter construction and body parsing. Chat module went from zero coverage to full boundary coverage

Closes #145

## Test plan
- [x] `npx vitest run` (153/153 passing, including 11 new tests)
- [x] `npx tsc --noEmit` clean
- [ ] Manually verify `/api/chat` still returns 401 without a valid session cookie
- [ ] Manually verify chat streaming still works end-to-end in the UI
- [ ] Manually verify `get_weekly_menu` and `add_to_weekly_menu` tools still fire through the chat